### PR TITLE
Remove Enderium Spawn Egg Mutation

### DIFF
--- a/config/resourcefulbees/bees/gem/Diamond.json
+++ b/config/resourcefulbees/bees/gem/Diamond.json
@@ -29,11 +29,6 @@
                 "type": "BLOCK",
                 "inputID": "create:granite_cobblestone",
                 "outputs": [{ "outputID": "emendatusenigmatica:diamond_granite_ore", "weight": 10 }]
-            },
-            {
-                "type": "ITEM",
-                "inputID": "resourcefulbees:ender_honeycomb_block",
-                "outputs": [{ "outputID": "resourcefulbees:enderium_bee_spawn_egg", "weight": 10 }]
             }
         ]
     },


### PR DESCRIPTION
Removes the spawn egg mutation for the Enderium Bee from the Diamond Bee. This should force use of the Induction Smelter recipe.