### PR TITLE
[Expert] Fix T2 Apiary Recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -405,7 +405,7 @@ onEvent('recipes', (event) => {
                 'naturesaura:aura_bloom',
                 '#resourcefulbees:resourceful_honeycomb_block'
             ],
-            reagent: 'resourcefulbees:t1_apiary',
+            reagent: Item.of('resourcefulbees:t1_apiary').ignoreNBT(),
             sourceCost: 5000,
             output: 'resourcefulbees:t2_apiary',
             id: 'resourcefulbees:t2_apiary'


### PR DESCRIPTION
Add `.ignoreNBT()` to make T2 recipe work with T1 apiaries that have been placed.