### PR TITLE
Bee Fixes

### DIFF
--- a/config/resourcefulbees/bees/dev/Kitten.json
+++ b/config/resourcefulbees/bees/dev/Kitten.json
@@ -1,0 +1,44 @@
+{
+    "beeVersion": 0.10,
+    "flower": "tag:minecraft:beds",
+    "baseLayerTexture": "kitten/bee",
+    "creator": "Dawn Felstar",
+    "lore": "Cute little baby kitten bee.",
+    "loreColor": "rainbow",
+    "traits": ["kitten"],
+    "customCombDrop": "resourcefulbees:catnip_honeycomb",
+    "customCombBlockDrop": "resourcefulbees:catnip_honeycomb_block",
+    "sizeModifier": 0.75,
+    "maxTimeInHive": 500,
+    "hasHoneycomb": true,
+    "ColorData" : {
+      "isBeeColored": false,
+      "modelType": "KITTEN",
+      "primaryColor": "#EAA939",
+      "secondaryColor": "#4C483B"
+    },
+    "CentrifugeData": {
+      "hasCentrifugeOutput": true,
+      "mainOutput": "minecraft:cat_spawn_egg",
+      "mainOutputWeight": 0.01,
+      "bottleOutput": "resourcefulbees:catnip_honey_bottle",
+      "bottleOutputWeight": 0.1
+    },
+    "CombatData": {
+      "isPassive": false,
+      "attackDamage": 0,
+      "baseHealth": 20,
+      "removeStingerOnAttack": false
+    },
+    "SpawnData" : {
+      "canSpawnInWorld": true,
+      "spawnWeight": 3,
+      "biomeWhitelist": "tag:rare",
+      "lightLevel": "DAY",
+      "minGroupSize": 1,
+      "maxGroupSize": 1
+    },
+    "TraitData": {
+      "hasTraits": true
+    }
+  }

--- a/config/resourcefulbees/bees/dev/Oreo.json
+++ b/config/resourcefulbees/bees/dev/Oreo.json
@@ -1,0 +1,37 @@
+{
+  "beeVersion": 0.10,
+  "flower": "ALL",
+  "baseLayerTexture": "oreo/oreo_bee",
+  "creator": "Epic Oreo",
+  "lore": "A Delicious Bee",
+  "loreColor": "rainbow",
+  "traits": ["oreo"],
+  "apiaryOutputAmounts": [1, 2, 3, 4],
+  "customCombDrop": "resourcefulbees:oreo_cookie",
+  "customCombBlockDrop": "resourcefulbees:oreo_cookie",
+  "sizeModifier": 1.5,
+  "maxTimeInHive": 6000,
+  "hasHoneycomb": true,
+  "ColorData" : {
+    "isBeeColored": false,
+    "primaryColor": "#442920",
+    "secondaryColor": "#e1d9b8"
+  },
+  "CombatData": {
+    "isPassive": false,
+    "attackDamage": 0,
+    "baseHealth": 20,
+    "removeStingerOnAttack": false
+  },
+  "SpawnData" : {
+    "canSpawnInWorld": true,
+    "spawnWeight": 3,
+    "biomeWhitelist": "tag:rare",
+    "lightLevel": "DAY",
+    "minGroupSize": 1,
+    "maxGroupSize": 1
+  },
+  "TraitData": {
+    "hasTraits": true
+  }
+}

--- a/config/resourcefulbees/bees/dev/Starry_Lexxie.json
+++ b/config/resourcefulbees/bees/dev/Starry_Lexxie.json
@@ -1,0 +1,64 @@
+{
+  "beeVersion": 0.10,
+  "flower": "minecraft:beacon",
+  "maxTimeInHive": 1200,
+  "traits": ["starry"],
+  "creator": "Lady Lexxie",
+  "lore": "Reach for the stars!",
+  "loreColor": "rainbow",
+  "sizeModifier": 1.25,
+  "hasHoneycomb": true,
+  "apiaryOutputAmounts": [1, 1, 1, 1, 1],
+  "apiaryOutputTypes": ["COMB", "COMB", "COMB", "COMB", "COMB"],
+  "honeycombRarity": "EPIC",
+  "baseLayerTexture": "empty_layer",
+  "ColorData": {
+    "isBeeColored": true,
+    "primaryColor": "#FFFFFF",
+    "secondaryColor": "#FFA500",
+    "honeycombColor": "#FFA500",
+    "primaryLayerTexture": "starry/starry_bee_primary_layer",
+    "secondaryLayerTexture": "empty_layer",
+    "emissiveLayerTexture": "starry/starry_bee_emissive",
+    "isGlowing": true,
+    "glowColor": "#FFA500",
+    "glowingPulse": 1,
+    "modelType": "QUEEN"
+  },
+  "MutationData": {
+    "hasMutation": true,
+    "mutations": [{
+      "type": "ITEM",
+      "inputID": "resourcefulbees:starry_honey_block",
+      "outputs": [{
+        "outputID": "minecraft:nether_star",
+        "chance": 0.1
+      }]
+    }]
+  },
+  "CombatData": {
+    "isInvulnerable": true,
+    "removeStingerOnAttack": false,
+    "baseHealth": 20,
+    "attackDamage": 0
+  },
+  "CentrifugeData": {
+    "hasCentrifugeOutput": true,
+    "mainOutput": "resourcefulbees:starry_honey",
+    "mainOutputWeight": 0.1,
+    "mainOutputCount": 5,
+    "hasFluidOutput": true
+  },
+  "SpawnData": {
+    "canSpawnInWorld": true,
+    "biomeWhitelist": "minecraft:small_end_islands",
+    "spawnWeight": 2,
+    "minGroupSize": 1,
+    "maxGroupSize": 1,
+    "minYLevel": 50,
+    "maxYLevel": 80
+  },
+  "TraitData": {
+    "hasTraits": true
+  }
+}

--- a/config/resourcefulbees/bees/dev/Yeti.json
+++ b/config/resourcefulbees/bees/dev/Yeti.json
@@ -1,0 +1,48 @@
+{
+  "beeVersion": 0.10,
+  "flower": "minecraft:snow_block",
+  "baseLayerTexture": "yeti/yeti_bee",
+  "creator": "Joosh",
+  "lore": "A pretty §ocool§r bee.\nHe's here to bee your best friend :)",
+  "loreColor": "#ADD8E6",
+  "traits": ["oreo"],
+  "sizeModifier": 1.25,
+  "maxTimeInHive": 6000,
+  "hasHoneycomb": false,
+  "ColorData" : {
+    "isBeeColored": false,
+    "primaryColor": "#E9F4F6",
+    "secondaryColor": "#777E86",
+    "modelType": "YETI"
+  },
+  "CombatData": {
+    "isPassive": false,
+    "attackDamage": 0,
+    "baseHealth": 20,
+    "removeStingerOnAttack": false
+  },
+  "MutationData": {
+    "hasMutation": true,
+    "mutationCount": 30,
+    "mutations": [
+      {
+        "type": "BLOCK",
+        "inputID": "minecraft:water",
+        "outputs": [
+          {"outputID": "minecraft:ice"}
+        ]
+      }
+    ]
+  },
+  "SpawnData" : {
+    "canSpawnInWorld": true,
+    "spawnWeight": 2,
+    "biomeWhitelist": "tag:snowy",
+    "lightLevel": "DAY",
+    "minGroupSize": 1,
+    "maxGroupSize": 1
+  },
+  "TraitData": {
+    "hasTraits": true
+  }
+}

--- a/config/resourcefulbees/common.toml
+++ b/config/resourcefulbees/common.toml
@@ -139,7 +139,7 @@
 	#
 	#Set to true if you want easter egg bees to generate (WIP) [true/false]
 	#The only easter egg bee currently available is the Oreo bee
-	enableEasterEggBees = true
+	enableEasterEggBees = false
 	#
 	#Set this to false when you want to overwrite the default bee files. [true/false]
 	#This should be run at least once for initial generation.

--- a/config/resourcefulbees/honey/Starry.json
+++ b/config/resourcefulbees/honey/Starry.json
@@ -1,0 +1,13 @@
+{
+    "honeyVersion": 0.10,
+    "honeyColor": "#FFA500",
+    "hunger": 20,
+    "saturation": 1,
+    "honeyRarity": "EPIC",
+    "effects": [
+      {
+        "effectID": "minecraft:glowing",
+        "duration": 2400
+      }
+    ]
+  }

--- a/config/resourcefulbees/resources/assets/resourcefulbees/lang/en_us.json
+++ b/config/resourcefulbees/resources/assets/resourcefulbees/lang/en_us.json
@@ -354,10 +354,10 @@
    "item.resourcefulbees.bloody_bee_spawn_egg": "Bloody Bee Spawn Egg",
    "entity.resourcefulbees.bloody_bee": "Bloody Bee",
    
-   "block.resourcefulbees.starry_honeycomb_block": "Starry Honeycomb Block",
-   "item.resourcefulbees.starry_honeycomb": "Starry Honeycomb",
-   "item.resourcefulbees.starry_bee_spawn_egg": "Starry Bee Spawn Egg",
-   "entity.resourcefulbees.starry_bee": "Starry Bee",
+   "block.resourcefulbees.starry_honeycomb_block": "Celestial Honeycomb Block",
+   "item.resourcefulbees.starry_honeycomb": "Celestial Honeycomb",
+   "item.resourcefulbees.starry_bee_spawn_egg": "Celestial Bee Spawn Egg",
+   "entity.resourcefulbees.starry_bee": "Celestial Bee",
    
    "block.resourcefulbees.cobalt_honeycomb_block": "Cobalt Honeycomb Block",
    "item.resourcefulbees.cobalt_honeycomb": "Cobalt Honeycomb",
@@ -446,8 +446,8 @@
    "item.resourcefulbees.brutish_zombee_bee_spawn_egg": "Brutish Zombee Spawn Egg",
    "entity.resourcefulbees.brutish_zombee_bee": "Brutish Zombee",
    
-   "block.resourcefulbees.otherworldly_honeycomb_block": "Otherworldly Bee Honeycomb Block",
-   "item.resourcefulbees.otherworldly_honeycomb": "Otherworldly Bee Honeycomb",
+   "block.resourcefulbees.otherworldly_honeycomb_block": "Otherworldly Honeycomb Block",
+   "item.resourcefulbees.otherworldly_honeycomb": "Otherworldly Honeycomb",
    "item.resourcefulbees.otherworldly_bee_spawn_egg": "Otherworldly Bee Spawn Egg",
    "entity.resourcefulbees.otherworldly_bee": "Otherworldly Bee",
    
@@ -456,8 +456,8 @@
    "item.resourcefulbees.carbee_bee_spawn_egg": "Carbee Spawn Egg",
    "entity.resourcefulbees.carbee_bee": "Carbee",
    
-   "block.resourcefulbees.shepherd_honeycomb_block": "Shepherd Bee Honeycomb Block",
-   "item.resourcefulbees.shepherd_honeycomb": "Shepherd Bee Honeycomb",
+   "block.resourcefulbees.shepherd_honeycomb_block": "Shepherd Honeycomb Block",
+   "item.resourcefulbees.shepherd_honeycomb": "Shepherd Honeycomb",
    "item.resourcefulbees.shepherd_bee_spawn_egg": "Shepherd Bee Spawn Egg",
    "entity.resourcefulbees.shepherd_bee": "Shepherd Bee",
    
@@ -466,18 +466,18 @@
    "item.resourcefulbees.dusty_mummbee_bee_spawn_egg": "Dusty Mummbee Spawn Egg",
    "entity.resourcefulbees.dusty_mummbee_bee": "Dusty Mummbee",
    
-   "block.resourcefulbees.clogged_honeycomb_block": "Clogged Bee Honeycomb Block",
-   "item.resourcefulbees.clogged_honeycomb": "Clogged Bee Honeycomb",
+   "block.resourcefulbees.clogged_honeycomb_block": "Clogged Honeycomb Block",
+   "item.resourcefulbees.clogged_honeycomb": "Clogged Honeycomb",
    "item.resourcefulbees.clogged_bee_spawn_egg": "Clogged Bee Spawn Egg",
    "entity.resourcefulbees.clogged_bee": "Clogged Bee",
    
-   "block.resourcefulbees.frosty_honeycomb_block": "Frosty Bee Honeycomb Block",
-   "item.resourcefulbees.frosty_honeycomb": "Frosty Bee Honeycomb",
+   "block.resourcefulbees.frosty_honeycomb_block": "Frosty Honeycomb Block",
+   "item.resourcefulbees.frosty_honeycomb": "Frosty Honeycomb",
    "item.resourcefulbees.frosty_bee_spawn_egg": "Frosty Bee Spawn Egg",
    "entity.resourcefulbees.frosty_bee": "Frosty Bee",
    
-   "block.resourcefulbees.regal_honeycomb_block": "Regal Bee Honeycomb Block",
-   "item.resourcefulbees.regal_honeycomb": "Regal Bee Honeycomb",
+   "block.resourcefulbees.regal_honeycomb_block": "Regal Honeycomb Block",
+   "item.resourcefulbees.regal_honeycomb": "Regal Honeycomb",
    "item.resourcefulbees.regal_bee_spawn_egg": "Regal Bee Spawn Egg",
    "entity.resourcefulbees.regal_bee": "Regal Bee",
 
@@ -489,5 +489,10 @@
    "fluid.resourcefulbees.otherworldly_honey": "Otherworldly Honey",
    "item.resourcefulbees.otherworldly_honey_bottle": "Otherworldly Honey Bottle",
    "item.resourcefulbees.otherworldly_honey_fluid_bucket": "Otherworldly Honey Bucket",
-   "block.resourcefulbees.otherworldly_honey_block": "Otherworldly Honey Block"
+   "block.resourcefulbees.otherworldly_honey_block": "Otherworldly Honey Block",
+   
+   "block.resourcefulbees.starry_lexxie_honeycomb_block": "Starry Honeycomb Block",
+   "item.resourcefulbees.starry_lexxie_honeycomb": "Starry Honeycomb",
+   "item.resourcefulbees.starry_lexxie_bee_spawn_egg": "Starry Bee Spawn Egg",
+   "entity.resourcefulbees.starry_lexxie_bee": "Starry Bee"
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -382,10 +382,10 @@ onEvent('recipes', (event) => {
             inputs: [
                 '#resourcefulbees:resourceful_honeycomb_block',
                 'minecraft:sunflower',
-                'resourcefulbees:honey_fluid_bucket',
+                '#resourcefulbees:resourceful_honey_block',
                 '#botania:runes/earth',
                 '#botania:runes/air',
-                'resourcefulbees:honey_fluid_bucket',
+                '#resourcefulbees:resourceful_honey_block',
                 'naturesaura:aura_bloom',
                 '#resourcefulbees:resourceful_honeycomb_block'
             ],


### PR DESCRIPTION
Fixes the collision between the new Dev Bee and our existing Starry Bee.

Updates the [Expert] recipe for the T2 Apiary in the Enchantment Apparatus, to use Resourceful Honey Blocks in lieu of Honey Buckets. This will prevent clogging the pedestals.