### PR TITLE
sequenced assembly armors use the base armor

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -1059,30 +1059,30 @@ onEvent('recipes', (event) => {
     armorTypes.forEach((armorType) => {
         armorType.armors.forEach((armor) => {
             recipes.push({
-                input: Item.of(armor.base, '{Damage:0}').weakNBT(),
+                input: Ingredient.customNBT(Item.of(armor.base, '{Damage:0}').weakNBT(), nbt => !nbt.SequencedAssembly),
                 outputs: [armor.result],
-                transitionalItem: armor.material,
+                transitionalItem: armor.base,
                 loops: armorType.loops,
                 sequence: [
                     {
                         type: 'deploying',
-                        input: [armor.material, armor.material],
-                        output: armor.material
+                        input: [armor.base, armor.material],
+                        output: armor.base
                     },
                     {
                         type: 'pressing',
-                        input: armor.material,
-                        output: armor.material
+                        input: armor.base,
+                        output: armor.base
                     },
                     {
                         type: 'pressing',
-                        input: armor.material,
-                        output: armor.material
+                        input: armor.base,
+                        output: armor.base
                     },
                     {
                         type: 'pressing',
-                        input: armor.material,
-                        output: armor.material
+                        input: armor.base,
+                        output: armor.base
                     }
                 ],
                 id: armor.id


### PR DESCRIPTION
Currently the material ingot is the transitional item, which feels visually odd (chainmail -> ingot -> finished armor).

Switch the transitional item to the base armor. The custom NBT ingredient makes sure only non-partially assembled recipes can be used as an input ingredient. Otherwise, all the recipes using identical transitional item and base armors conflict.

![Capture](https://user-images.githubusercontent.com/75914799/149287771-63d897cf-c129-406d-a774-d586c8c5de3a.PNG)
![Capture2](https://user-images.githubusercontent.com/75914799/149287560-aebadd2a-a0a2-4709-8290-b664882c09f4.PNG)
![Capture3](https://user-images.githubusercontent.com/75914799/149287561-061ecd92-1724-4be6-aa94-f089d6502cbe.PNG)
