### PR TITLE
Saner default rankds

### DIFF
--- a/defaultconfigs/ftbranks/ranks.snbt
+++ b/defaultconfigs/ftbranks/ranks.snbt
@@ -4,22 +4,31 @@
 		power: 1
 		condition: "always_active"
 		ftbranks.name_format: "<{name}>"
-		ftbchunks.max_claimed: 1000,
-        ftbchunks.max_force_loaded: 25,
-        command.back: false,
-        command.warp: false,
-        command.setwarp: false,
-        command.delwarp: false,
-        command.listwarps: false,
-        command.home: false,
-        command.sethome: false,
-        command.delhome: false,
-        command.listhome: false
+		ftbchunks.max_claimed: 1000
+		ftbchunks.max_force_loaded: 25
+		command.back: false
+		command.warp: false
+		command.setwarp: false
+		command.delwarp: false
+		command.listwarps: false
+		command.home: false
+		command.sethome: false
+		command.delhome: false
+		command.listhome: false
 	}
 	admin: {
 		name: "Admin"
 		power: 1000
 		condition: "op"
 		ftbranks.name_format: "<&2{name}&r>"
+		command.back: true
+		command.warp: true
+		command.setwarp: true
+		command.delwarp: true
+		command.listwarps: true
+		command.home: true
+		command.sethome: true
+		command.delhome: true
+		command.listhome: true
 	}
 }


### PR DESCRIPTION
Gives the admin default access to the commands, and thus would allow singleplayers to actually get access to the command through `/ftbranks add @p Admin` instead telling  people to edit a file.