### PR TITLE
Some Atum QOL suggestions

### DIFF
--- a/config/ftbquests/quests/chapters/adventure.snbt
+++ b/config/ftbquests/quests/chapters/adventure.snbt
@@ -263,9 +263,9 @@
 				""
 				"Nebu Ore can be found deep underground and is used to craft Nebu Torches, the key to opening the pyramids that dot the land. "
 				""
-				"Gather some torches, then seek out the buried entrance to a pyramid. Place torches on each Quandry Block located near the entrance to open the way. "
+				"Gather some torches, then seek out the buried entrance to a pyramid. Place torches on each Quandary Block located near the entrance to open the way. "
 				""
-				"Once inside, tread carefully and seek out the Pharaoh’s Chamber where more Quandry Blocks will need to be activated. With all of them lit up, the Sarcophagus’ treasures are yours to plunder. "
+				"Once inside, tread carefully and seek out the Pharaoh’s Chamber where more Quandary Blocks will need to be activated. With all of them lit up, the Sarcophagus’ treasures are yours to plunder. "
 			]
 			hide_dependency_lines: true
 			dependencies: ["7FCB0C026902B90C"]

--- a/defaultconfigs/scannable-server.toml
+++ b/defaultconfigs/scannable-server.toml
@@ -59,7 +59,7 @@
 	#Registry names of blocks considered 'common ores', requiring the common ore scanner module.
 	commonOreBlocks = ["minecraft:clay", "atum:marl", "upgrade_aquatic:embedded_ammonite", "quark:red_crystal", "quark:orange_crystal", "quark:yellow_crystal", "quark:green_crystal", "quark:blue_crystal", "quark:indigo_crystal", "quark:violet_crystal", "quark:white_crystal", "quark:black_crystal"]
 	#Block tags of blocks considered 'common ores', requiring the common ore scanner module.
-	commonOreBlockTags = ["forge:ores/iron", "forge:ores/redstone", "forge:ores/coal", "forge:ores/quartz", "forge:ores/lead", "forge:ores/tin", "forge:ores/lapis", "forge:ores/copper", "forge:ores/nickel", "forge:ores/bitumen", "forge:ores/apatite", "forge:ores/potassium_nitrate"]
+	commonOreBlockTags = ["forge:ores/iron", "forge:ores/redstone", "forge:ores/coal", "forge:ores/quartz", "forge:ores/lead", "forge:ores/tin", "forge:ores/lapis", "forge:ores/copper", "forge:ores/nickel", "forge:ores/bitumen", "forge:ores/apatite", "forge:ores/potassium_nitrate", "forge:ores/bone"]
 	#Registry names of blocks considered 'rare ores', requiring the common ore scanner module.
 	rareOreBlocks = ["minecraft:glowstone"]
 	#Block tags of blocks considered 'rare ores', requiring the common ore scanner module.
@@ -74,4 +74,3 @@
 [structures]
 	#The list of structures the structure module scans for.
 	structures = []
-

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -211,6 +211,28 @@ onEvent('recipes', (event) => {
                 event.shapeless(Item.of(block, 1), [dyeTag, itemTag]);
             }
         );
+
+        ['linen', 'linen_carpet'].forEach(
+            (blockName) => {
+                var itemTag = `#atum:${blockName}`;
+                var block = `atum:${blockName}_${color}`;
+
+                if (blockName == 'linen_carpet') {
+                    event.remove({ id: `atum:${color}_linen_carpet_from_white_linen_carpet` });
+                } else if (blockName == 'linen') {
+                    if (color != 'white') { // linen_white is Atum's linen cloth -> linen recipe
+                        event.remove({ id: `atum:linen_${color}` });
+                    }
+                }
+
+                event.shaped(Item.of(block, 8), ['SSS', 'SDS', 'SSS'], {
+                    S: itemTag,
+                    D: dyeTag
+                }).id(`kubejs:${blockName}_${color}_bulk`);
+                event.shapeless(Item.of(block, 1), [dyeTag, itemTag]).id(`kubejs:${blockName}_${color}`);
+            }
+        );
+
         event.shapeless(Item.of(`minecraft:${color}_concrete_powder`, 8), [
             dyeTag,
             '#forge:sand',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
@@ -24,7 +24,9 @@ onEvent('recipes', (event) => {
                 { item: 'sushigocrafting:wasabi_root', chance: 0.65 },
                 { item: 'sushigocrafting:soy_bean', chance: 0.65 },
                 { item: 'sushigocrafting:cucumber', chance: 0.65 },
-                { item: 'sushigocrafting:rice', chance: 0.65 }
+                { item: 'sushigocrafting:rice', chance: 0.65 },
+
+                { item: 'atum:flax_seeds', chance: 0.3 }
             ],
             remove: [],
             change: []

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
@@ -162,6 +162,24 @@ onEvent('recipes', (event) => {
             output: 'thermal:white_rockwool',
             xp: 0.1,
             id: 'thermal:rockwool/white_rockwool_from_blasting'
+        },
+        {
+            input: 'atum:bone_ore',
+            output: Item.of('atum:dusty_bone', 2),
+            xp: 0.7,
+            id: `${id_prefix}atum_bone_ore`
+        },
+        {
+            input: 'atum:khnumite_raw',
+            output: Item.of('atum:khnumite', 3),
+            xp: 0.7,
+            id: `${id_prefix}atum_khnumite_raw`
+        },
+        {
+            input: 'atum:relic_ore',
+            output: 'minecraft:gold_ingot',
+            xp: 0.7,
+            id: `${id_prefix}atum_relic_ore`
         }
     ];
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
@@ -156,6 +156,18 @@ onEvent('recipes', (event) => {
             output: 'atum:ceramic_white',
             xp: 0.3,
             id: `${id_prefix}ceramic_white`
+        },
+        {
+            input: 'atum:bone_ore',
+            output: Item.of('atum:dusty_bone', 2),
+            xp: 0.7,
+            id: `${id_prefix}atum_bone`
+        },
+        {
+            input: 'atum:khnumite_raw',
+            output: Item.of('atum:khnumite', 3),
+            xp: 0.7,
+            id: `${id_prefix}atum_khnumite_raw`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
@@ -171,6 +171,41 @@ onEvent('recipes', (event) => {
         }
     ];
 
+    let atumRecyclables = {
+        "iron": [
+            'desert_boots_iron',
+            'desert_chest_iron',
+            'desert_helmet_iron',
+            'desert_legs_iron',
+            'iron_club',
+            'iron_dagger',
+            'iron_khopesh',
+            'iron_greatsword',
+            'iron_scimitar',
+            'camel_iron_armor',
+            'desert_wolf_iron_armor'
+        ],
+        "gold": [
+            'desert_boots_gold',
+            'desert_chest_gold',
+            'desert_helmet_gold',
+            'desert_legs_gold',
+            'camel_gold_armor',
+            'desert_wolf_gold_armor'
+        ]
+    };
+
+    Object.keys(atumRecyclables).forEach((mat) => {
+        atumRecyclables[mat].forEach((item) => {
+            recipes.push({
+                input: Item.of(`atum:${item}`).ignoreNBT(),
+                output: `minecraft:${mat}_nugget`,
+                xp: 0.1,
+                id: `${id_prefix}${mat}_nugget_from_${item}`
+            });
+        });
+    });
+
     var stones = [
         'granite',
         'diorite',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
@@ -161,13 +161,19 @@ onEvent('recipes', (event) => {
             input: 'atum:bone_ore',
             output: Item.of('atum:dusty_bone', 2),
             xp: 0.7,
-            id: `${id_prefix}atum_bone`
+            id: `${id_prefix}atum_bone_ore`
         },
         {
             input: 'atum:khnumite_raw',
             output: Item.of('atum:khnumite', 3),
             xp: 0.7,
             id: `${id_prefix}atum_khnumite_raw`
+        },
+        {
+            input: 'atum:relic_ore',
+            output: 'minecraft:gold_ingot',
+            xp: 0.7,
+            id: `${id_prefix}atum_relic_ore`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
@@ -8,7 +8,9 @@ onEvent('block.tags', (event) => {
         'minecraft:ancient_debris',
         'occultism:iesnium_ore',
         'byg:cryptic_redstone_ore',
-        'betterendforge:thallasium_ore'
+        'betterendforge:thallasium_ore',
+        'atum:bone_ore',
+        'atum:relic_ore'
     ]);
 
     event.add('forge:ores/dimensional', [

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/atum/linen.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/atum/linen.js
@@ -1,0 +1,6 @@
+onEvent('item.tags', (event) => {
+    colors.forEach((color) => {
+        event.get('atum:linen').add(`atum:linen_${color}`);
+        event.get('atum:linen_carpet').add(`atum:linen_carpet_${color}`);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
@@ -8,7 +8,9 @@ onEvent('item.tags', (event) => {
         'minecraft:ancient_debris',
         'occultism:iesnium_ore',
         'byg:cryptic_redstone_ore',
-        'betterendforge:thallasium_ore'
+        'betterendforge:thallasium_ore',
+        'atum:bone_ore',
+        'atum:relic_ore'
     ]);
 
     event.add('forge:ores/dimensional', [


### PR DESCRIPTION
In commit order, feel free to take none or any of these:

* Silk touch is borderline a downside in Atum because you can't process Bone, Relic, or Khnumite. Add smelting recipes for bone (usually drops 1-3) and khnumite (usually drops 2-4). I don't know what to do about Relic Ore; I don't think there's a sensible way to average that loot table.
* Atum gold / iron tools and armor are now recyclable like their vanilla counterparts. Makes the bandit and chest trash slightly less annoying at least.
* Add `forge:ores` to Bone Ore and Relic Ore so that they scan properly. Also make Bone Ore scan as common.
* Flax seed is, unlike every other seed, not compostable.
* `Quandry` -> `Quandary`.
* Add the dye QOL that exists for normal wool and carpet to linen and linen carpet. I was thinking about doing this for ceramic and crystal glass too, but it seems like there's already something in place for ceramic and there are so many versions of glass.