### PR TITLE
Ancient Wood sawing and rod improvements

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/shaped.js
@@ -1,4 +1,5 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/minecraft/shaped/';
     const recipes = [
         {
             output: 'minecraft:pumpkin_pie',
@@ -35,6 +36,14 @@ onEvent('recipes', (event) => {
                 A: 'minecraft:stone'
             },
             id: 'minecraft:stone_bricks'
+        },
+        {
+            output: Item.of('2x minecraft:stick'),
+            pattern: ['A', 'A'],
+            key: {
+                A: 'naturesaura:ancient_stick'
+            },
+            id: `${id_prefix}stick`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/rods.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/rods.js
@@ -3,4 +3,5 @@ onEvent('item.tags', (event) => {
     event.get('forge:rods/basalz').add('thermal:basalz_rod');
     event.get('forge:rods/blizz').add('thermal:blizz_rod');
     event.get('forge:rods/blitz').add('thermal:blitz_rod');
+    event.get('forge:rods/wooden').remove('naturesaura:ancient_stick');
 });


### PR DESCRIPTION
Removes Ancient Wood Rods from the wooden rods tag so they're no longer accidentally pulled instead of sticks in automation

Created a conversion recipe instead if someone still wants to use them as sticks...
![image](https://user-images.githubusercontent.com/9543430/149632413-a1650393-2557-48fc-8434-988acb7ffe52.png)

Also adds sawing recipes for ancient planks
![image](https://user-images.githubusercontent.com/9543430/149633145-e52fdd22-a307-4f2b-8671-88f67f4b5862.png)


