### PR TITLE
manually add glass to stonecutter tag

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/stonecutter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/stonecutter.js
@@ -5,4 +5,36 @@ onEvent('item.tags', (event) => {
         event.add(tag, stoneType.stones);
         event.add(tag, stoneType.onlyAsInput);
     });
+
+    const glassTypes = [`glass`, 'glass_panes'];
+    glassTypes.forEach((glassType) => {
+        let glassesInTag = getItemsInTag(Ingredient.of(`#forge:${glassType}/colorless`)),
+            glasses = [];
+
+        glassesInTag.forEach((glass) => {
+            let modId = glass.id.split(':')[0];
+            if (modId == 'atum' || modId == 'tconstruct') {
+                return;
+            }
+            glasses.push(glass.id);
+        });
+
+        event.get(`enigmatica:stonecuttables/colorless_${glassType}`).add(glasses);
+    });
+
+    colors.forEach((color) => {
+        glassTypes.forEach((glassType) => {
+            let glassesInTag = getItemsInTag(Ingredient.of(`#forge:${glassType}/${color}`)),
+                glasses = [];
+
+            glassesInTag.forEach((glass) => {
+                let modId = glass.id.split(':')[0];
+                if (modId == 'atum') {
+                    return;
+                }
+                glasses.push(glass.id);
+            });
+            event.get(`enigmatica:stonecuttables/${color}_${glassType}`).add(glasses);
+        });
+    });
 });


### PR DESCRIPTION
Seems they're not getting added to the tag in their new home, causing a bunch of warnings in the logs