### PR TITLE
Fix tc quests giving wrong molten metals

### DIFF
--- a/kubejs/data/enigmatica/loot_tables/chests/quest_tinkers_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_tinkers_legendary.json
@@ -82,7 +82,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{fluid:\"emendatusenigmatica:molten_signalum\"}"
+                            "tag": "{fluid:\"tconstruct:molten_signalum\"}"
                         }
                     ]
                 },
@@ -104,7 +104,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{fluid:\"emendatusenigmatica:molten_lumium\"}"
+                            "tag": "{fluid:\"tconstruct:molten_lumium\"}"
                         }
                     ]
                 },
@@ -181,7 +181,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{tank:{FluidName:\"emendatusenigmatica:molten_lumium\",Amount:100}}"
+                            "tag": "{tank:{FluidName:\"tconstruct:molten_lumium\",Amount:100}}"
                         }
                     ]
                 },
@@ -192,7 +192,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{tank:{FluidName:\"emendatusenigmatica:molten_signalum\",Amount:100}}"
+                            "tag": "{tank:{FluidName:\"tconstruct:molten_signalum\",Amount:100}}"
                         }
                     ]
                 },


### PR DESCRIPTION
These two quests give the wrong fluid, which can't actually be used for anything.