### PR TITLE
Reduce Sooty Spawn Weight

### DIFF
--- a/config/resourcefulbees/bees/natural/Coal.json
+++ b/config/resourcefulbees/bees/natural/Coal.json
@@ -57,7 +57,7 @@
         "biomeBlacklist": "tag:OCEAN",
         "minGroupSize": 2,
         "maxGroupSize": 3,
-        "spawnWeight": 12,
+        "spawnWeight": 10,
         "minYLevel": 12,
         "maxYLevel": 75,
         "lightLevel": "ANY"


### PR DESCRIPTION
Reduced Sooty (Coal)'s spawn weight 12 -> 10. Let's see how this playtests & we can drop it more if need be. Fixes #4073.