### PR TITLE
[Expert] Machine Speed and Ore Processing tweaks

### DIFF
--- a/config/configswapper/expert/config/Mekanism/generators.toml
+++ b/config/configswapper/expert/config/Mekanism/generators.toml
@@ -1,0 +1,95 @@
+
+#Mekanism Generators Config. This config is synced between server and client.
+[generators]
+	#Peak output for the Advanced Solar Generator. Note: It can go higher than this value in some extreme environments.
+	advancedSolarGeneration = "640"
+	#Affects the Injection Rate, Max Temp, and Ignition Temp.
+	energyPerFusionFuel = "550000"
+	#Amount of energy in Joules the Bio Generator produces per tick.
+	bioGeneration = "350"
+	#Peak output for the Solar Generator. Note: It can go higher than this value in some extreme environments.
+	solarGeneration = "80"
+
+	#Wind Generator Settings
+	[generators.wind_generator]
+		#Minimum base generation value of the Wind Generator.
+		windGenerationMin = "60"
+		#The list of dimension ids that the Wind Generator will not generate power in.
+		windGenerationDimBlacklist = []
+		#The maximum Y value that affects the Wind Generators Power generation.
+		windGenerationMaxY = 90
+		#Maximum base generation value of the Wind Generator.
+		windGenerationMax = "300"
+		#The minimum Y value that affects the Wind Generators Power generation.
+		windGenerationMinY = 40
+
+	#Turbine Settings
+	[generators.turbine]
+		#The number of blades on each turbine coil per blade applied.
+		turbineBladesPerCoil = 4
+		#The rate at which steam is vented into the turbine.
+		turbineVentGasFlow = 32000.0
+		#The rate at which steam is dispersed into the turbine.
+		turbineDisperserGasFlow = 1280.0
+		#The rate at which steam is condensed in the turbine.
+		condenserRate = 64000
+
+	#Heat Generator Settings
+	[generators.heat_generator]
+		#Add this amount of Joules to the energy produced by a heat generator if it is in an 'ultrawarm' dimension, in vanilla this is just the Nether.
+		heatGenerationNether = "100"
+		#Multiplier of effectiveness of Lava that is adjacent to the Heat Generator.
+		heatGenerationLava = "30"
+		#Amount of energy in Joules the Heat Generator produces per tick. heatGeneration + heatGenerationLava * lavaSides + heatGenerationNether. Note: lavaSides is how many sides are adjacent to lava, this includes the block itself if it is lava logged allowing for a max of 7 "sides".
+		heatGeneration = "200"
+		#The amount of lava in mB that gets consumed to transfer heatGeneration Joules to the Heat Generator.
+		#Range: 1 ~ 24000
+		heatGenerationFluidRate = 10
+
+	#Fission Reactor Settings
+	[generators.fission_reactor]
+		#The heat capacity added to a Fission Reactor by a single casing block. Increase to require more energy to raise the reactor temperature.
+		casingHeatCapacity = 1000.0
+		#The chance of a meltdown occurring once damage passes 100%. Will linearly scale as damage continues increasing.
+		#Range: 0.0 ~ 1.0
+		meltdownChance = 0.001
+		#Whether catastrophic meltdowns can occur from Fission Reactors. If disabled instead of melting down the reactor will turn off and not be able to be turned back on until the damage level decreases.
+		meltdownsEnabled = true
+		#How much radioactivity of fuel/waste contents are multiplied during a meltdown.
+		meltdownRadiationMultiplier = 50.0
+		#The average surface area of a Fission Reactor's fuel assemblies to reach 100% boil efficiency. Higher values make it harder to cool the reactor.
+		#Range: 1.0 ~ 1.7976931348623157E308
+		surfaceAreaTarget = 4.0
+		#Amount of energy created (in heat) from each whole mB of fission fuel.
+		energyPerFissionFuel = "1000000"
+		#The default burn rate of the fission reactor.
+		#Range: 0.001 ~ 1.0
+		defaultBurnRate = 0.1
+		#The burn rate increase each fuel assembly provides. Max Burn Rate = fuelAssemblies * burnPerAssembly
+		#Range: 1 ~ 1000000
+		burnPerAssembly = 1
+		#Damage to reset the reactor to after a meltdown.
+		#Range: 0.0 ~ 100.0
+		postMeltdownDamage = 75.0
+
+	#Hohlraum Settings
+	[generators.hohlraum]
+		#Amount of DT-Fuel Hohlraum can accept per tick.
+		#Range: 1 ~ 9223372036854775807
+		fillRate = 1
+		#Hohlraum capacity in mB.
+		#Range: 1 ~ 9223372036854775807
+		maxGas = 10
+
+	#Fusion Settings
+	[generators.fusion_reactor]
+		#The fraction of the heat dissipated from the case that is converted to Joules.
+		#Range: 0.0 ~ 1.0
+		thermocoupleEfficiency = 0.014
+		#The fraction fraction of heat from the casing that can be transferred to all sources that are not water. Will impact max heat, heat transfer to thermodynamic conductors, and power generation.
+		#Range: 0.001 ~ 1.0
+		casingThermalConductivity = 0.1
+		#The fraction of the heat from the casing that is dissipated to water when water cooling is in use. Will impact max heat, and steam generation.
+		#Range: 0.0 ~ 1.0
+		waterHeatingRatio = 0.3
+

--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -29,12 +29,12 @@
 	timeModifier = 0.25
 
 [machines.metal_press]
-		#A modifier to apply to the energy costs of every metal press recipe
-		#Range: 0.001 ~ 1000.0
-		energyModifier = 20.0
-		#A modifier to apply to the time of every metal press recipe
-		#Range: 0.001 ~ 1000.0
-		timeModifier = 0.1
+	#A modifier to apply to the energy costs of every metal press recipe
+	#Range: 0.001 ~ 1000.0
+	energyModifier = 20.0
+	#A modifier to apply to the time of every metal press recipe
+	#Range: 0.001 ~ 1000.0
+	timeModifier = 0.5
 
 [machines.crusher]
 	#A modifier to apply to the energy costs of every crusher recipe

--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -28,13 +28,21 @@
 	#Range: 0.001 ~ 1000.0
 	timeModifier = 0.25
 
+[machines.metal_press]
+		#A modifier to apply to the energy costs of every metal press recipe
+		#Range: 0.001 ~ 1000.0
+		energyModifier = 20.0
+		#A modifier to apply to the time of every metal press recipe
+		#Range: 0.001 ~ 1000.0
+		timeModifier = 0.1
+
 [machines.crusher]
 	#A modifier to apply to the energy costs of every crusher recipe
 	#Range: 0.001 ~ 1000.0
 	energyModifier = 25.6
 	#A modifier to apply to the time of every crusher recipe
 	#Range: 0.001 ~ 1000.0
-	timeModifier = 0.1
+	timeModifier = 0.05
 
 [machines.squeezer]
 	#A modifier to apply to the energy costs of every squeezer recipe

--- a/config/configswapper/normal/config/Mekanism/generators.toml
+++ b/config/configswapper/normal/config/Mekanism/generators.toml
@@ -1,0 +1,95 @@
+
+#Mekanism Generators Config. This config is synced between server and client.
+[generators]
+	#Peak output for the Advanced Solar Generator. Note: It can go higher than this value in some extreme environments.
+	advancedSolarGeneration = "300"
+	#Affects the Injection Rate, Max Temp, and Ignition Temp.
+	energyPerFusionFuel = "550000"
+	#Amount of energy in Joules the Bio Generator produces per tick.
+	bioGeneration = "350"
+	#Peak output for the Solar Generator. Note: It can go higher than this value in some extreme environments.
+	solarGeneration = "50"
+
+	#Wind Generator Settings
+	[generators.wind_generator]
+		#Minimum base generation value of the Wind Generator.
+		windGenerationMin = "60"
+		#The list of dimension ids that the Wind Generator will not generate power in.
+		windGenerationDimBlacklist = []
+		#The maximum Y value that affects the Wind Generators Power generation.
+		windGenerationMaxY = 90
+		#Maximum base generation value of the Wind Generator.
+		windGenerationMax = "300"
+		#The minimum Y value that affects the Wind Generators Power generation.
+		windGenerationMinY = 40
+
+	#Turbine Settings
+	[generators.turbine]
+		#The number of blades on each turbine coil per blade applied.
+		turbineBladesPerCoil = 4
+		#The rate at which steam is vented into the turbine.
+		turbineVentGasFlow = 32000.0
+		#The rate at which steam is dispersed into the turbine.
+		turbineDisperserGasFlow = 1280.0
+		#The rate at which steam is condensed in the turbine.
+		condenserRate = 64000
+
+	#Heat Generator Settings
+	[generators.heat_generator]
+		#Add this amount of Joules to the energy produced by a heat generator if it is in an 'ultrawarm' dimension, in vanilla this is just the Nether.
+		heatGenerationNether = "100"
+		#Multiplier of effectiveness of Lava that is adjacent to the Heat Generator.
+		heatGenerationLava = "30"
+		#Amount of energy in Joules the Heat Generator produces per tick. heatGeneration + heatGenerationLava * lavaSides + heatGenerationNether. Note: lavaSides is how many sides are adjacent to lava, this includes the block itself if it is lava logged allowing for a max of 7 "sides".
+		heatGeneration = "200"
+		#The amount of lava in mB that gets consumed to transfer heatGeneration Joules to the Heat Generator.
+		#Range: 1 ~ 24000
+		heatGenerationFluidRate = 10
+
+	#Fission Reactor Settings
+	[generators.fission_reactor]
+		#The heat capacity added to a Fission Reactor by a single casing block. Increase to require more energy to raise the reactor temperature.
+		casingHeatCapacity = 1000.0
+		#The chance of a meltdown occurring once damage passes 100%. Will linearly scale as damage continues increasing.
+		#Range: 0.0 ~ 1.0
+		meltdownChance = 0.001
+		#Whether catastrophic meltdowns can occur from Fission Reactors. If disabled instead of melting down the reactor will turn off and not be able to be turned back on until the damage level decreases.
+		meltdownsEnabled = true
+		#How much radioactivity of fuel/waste contents are multiplied during a meltdown.
+		meltdownRadiationMultiplier = 50.0
+		#The average surface area of a Fission Reactor's fuel assemblies to reach 100% boil efficiency. Higher values make it harder to cool the reactor.
+		#Range: 1.0 ~ 1.7976931348623157E308
+		surfaceAreaTarget = 4.0
+		#Amount of energy created (in heat) from each whole mB of fission fuel.
+		energyPerFissionFuel = "1000000"
+		#The default burn rate of the fission reactor.
+		#Range: 0.001 ~ 1.0
+		defaultBurnRate = 0.1
+		#The burn rate increase each fuel assembly provides. Max Burn Rate = fuelAssemblies * burnPerAssembly
+		#Range: 1 ~ 1000000
+		burnPerAssembly = 1
+		#Damage to reset the reactor to after a meltdown.
+		#Range: 0.0 ~ 100.0
+		postMeltdownDamage = 75.0
+
+	#Hohlraum Settings
+	[generators.hohlraum]
+		#Amount of DT-Fuel Hohlraum can accept per tick.
+		#Range: 1 ~ 9223372036854775807
+		fillRate = 1
+		#Hohlraum capacity in mB.
+		#Range: 1 ~ 9223372036854775807
+		maxGas = 10
+
+	#Fusion Settings
+	[generators.fusion_reactor]
+		#The fraction of the heat dissipated from the case that is converted to Joules.
+		#Range: 0.0 ~ 1.0
+		thermocoupleEfficiency = 0.014
+		#The fraction fraction of heat from the casing that can be transferred to all sources that are not water. Will impact max heat, heat transfer to thermodynamic conductors, and power generation.
+		#Range: 0.001 ~ 1.0
+		casingThermalConductivity = 0.1
+		#The fraction of the heat from the casing that is dissipated to water when water cooling is in use. Will impact max heat, and steam generation.
+		#Range: 0.0 ~ 1.0
+		waterHeatingRatio = 0.3
+

--- a/config/configswapper/normal/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/normal/serverconfig/immersiveengineering-server.toml
@@ -28,6 +28,14 @@
 	#Range: 0.001 ~ 1000.0
 	timeModifier = 1.0
 
+[machines.metal_press]
+	#A modifier to apply to the energy costs of every metal press recipe
+	#Range: 0.001 ~ 1000.0
+	energyModifier = 1.0
+	#A modifier to apply to the time of every metal press recipe
+	#Range: 0.001 ~ 1000.0
+	timeModifier = 1.0
+
 [machines.crusher]
 	#A modifier to apply to the energy costs of every crusher recipe
 	#Range: 0.001 ~ 1000.0

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -62,7 +62,7 @@ onEvent('recipes', (event) => {
             .id(`thermal:machine/press/press_${material}_ingot_to_gear`);
 
         event.recipes.immersiveengineering
-            .metal_press(output, Ingredient.of(input, 4), mold)
+            .metal_press(`4x ${output}`, Ingredient.of(`16x ${input}`), mold)
             .id(`kubejs:immersiveengineering_metal_press_${material}_gear`);
 
         event
@@ -100,7 +100,7 @@ onEvent('recipes', (event) => {
             .id(`kubejs:immersiveengineering_metal_press_${material}_rod`);
 
         event.recipes.immersiveengineering
-            .metal_press(rod, input, mold)
+            .metal_press(`4x ${rod}`, `4x ${input}`, mold)
             .id(`kubejs:immersiveengineering_metal_press_${material}_rod`);
 
         event.shapeless(output, [plateTag, hammer, plateTag]).id(`kubejs:shapeless_crafting_${material}_rod`);
@@ -129,7 +129,7 @@ onEvent('recipes', (event) => {
         event.shapeless(output, [input, hammer, input]).id(`kubejs:shapeless_crafting_${material}_plate`);
 
         event.recipes.immersiveengineering
-            .metal_press(output, input, mold)
+            .metal_press(`4x ${output}`, `4x ${input}`, mold)
             .id(`kubejs:immersiveengineering_metal_press_${material}_plate`);
 
         event.recipes.create.pressing(output, input).id(`kubejs:create_pressing_${material}_plate`);
@@ -165,7 +165,7 @@ onEvent('recipes', (event) => {
             .id(`kubejs:immersiveengineering_metal_press_${material}_wire`);
 
         event.recipes.immersiveengineering
-            .metal_press(Item.of(output, 4), plate, mold)
+            .metal_press(`16x ${output}`, `4x ${plate}`, mold)
             .id(`kubejs:immersiveengineering_metal_press_${material}_wire`);
 
         event.shapeless(Item.of(output, 2), [plate, plate, wireCutters]).id(`kubejs:shaped_crafting_${material}_wire`);
@@ -261,7 +261,7 @@ onEvent('recipes', (event) => {
                     { result: { item: secondary_fulminated_cluster, count: 1 }, weight: 5 },
                     { result: { item: 'thermal:slag', count: 1 }, weight: 35 }
                 ],
-                empty_weight: 50,
+                empty_weight: 0,
                 rolls: 20
             }
         });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -248,7 +248,7 @@ onEvent('recipes', (event) => {
             input: Ingredient.of(infusing_input).toJson(),
             output: { item: mana_cluster, count: 1 },
             catalyst: { type: 'block', block: 'naturesaura:generator_limit_remover' },
-            mana: 10000
+            mana: 2000
         });
 
         // Step Two: Zap!
@@ -257,11 +257,11 @@ onEvent('recipes', (event) => {
             inputs: [Ingredient.of(zapping_input).toJson()],
             output: {
                 entries: [
-                    { result: { item: fulminated_cluster, count: 1 }, weight: 10 },
-                    { result: { item: secondary_fulminated_cluster, count: 1 }, weight: 5 },
-                    { result: { item: 'thermal:slag', count: 1 }, weight: 35 }
+                    { result: { item: fulminated_cluster, count: 1 }, weight: 20 },
+                    { result: { item: secondary_fulminated_cluster, count: 1 }, weight: 10 },
+                    { result: { item: 'thermal:slag', count: 1 }, weight: 5 }
                 ],
-                empty_weight: 0,
+                empty_weight: 65,
                 rolls: 20
             }
         });
@@ -273,8 +273,8 @@ onEvent('recipes', (event) => {
             output: Ingredient.of(levigated_material).toJson(),
             catalyst: Ingredient.of('naturesaura:crushing_catalyst').toJson(),
             aura_type: 'naturesaura:overworld',
-            aura: 15000,
-            time: 80
+            aura: 1500,
+            time: 10
         });
 
         // Step Four: Freeze!
@@ -293,14 +293,14 @@ onEvent('recipes', (event) => {
                 rolls: 20
             },
             fluid: { fluid: 'astralsorcery:liquid_starlight' },
-            consume_fluid: 0.15
+            consume_fluid: 0.05
         });
 
         // Step Five: Fuse!
         event.custom({
             type: 'botania:runic_altar',
             output: { item: ingot, count: 1 },
-            mana: 25000,
+            mana: 2500,
             ingredients: [
                 Ingredient.of(fusing_input).toJson(),
                 Ingredient.of(fusing_input).toJson(),
@@ -311,7 +311,6 @@ onEvent('recipes', (event) => {
                 Ingredient.of(fusing_input).toJson(),
                 Ingredient.of(fusing_input).toJson(),
                 Ingredient.of(fusing_input).toJson(),
-                Ingredient.of('#forge:dusts/mana').toJson(),
                 Ingredient.of(`#botania:runes/nidavellir`).toJson()
             ]
         });


### PR DESCRIPTION
Speeds up crusher more to compete with Create crusher a bit better. 

Speeds up IE Metal Press by allowing it to do 4x recipes. This keeps the animation speed less insane, but ultimately makes it faster than the Thermal press. 

Buffs Mek solar. Still less than Powah solar and lower than other options at that stage, but this gives a little bit of reward for the high cost of crafting them early game.

Speeds up custom magical ore processing due to mana/aura throughput limitations by reducing required mana/aura. Also removes some consumables from the process and increases output rates. 