### PR TITLE
[Expert] Buff power output of Modular Routers

### DIFF
--- a/config/configswapper/expert/config/modularrouters-common.toml
+++ b/config/configswapper/expert/config/modularrouters-common.toml
@@ -1,0 +1,167 @@
+
+[Module]
+	#Should Breaker modules show particle effects when working?
+	breakerParticles = true
+	#Base range for Puller Mk2 (no range upgrades)
+	#Range: > 1
+	puller2BaseRange = 12
+	#Base range for Sender Mk2 (no range upgrades)
+	#Range: > 1
+	sender2BaseRange = 24
+	#Max range for Sender Mk2
+	#Range: > 1
+	sender2MaxRange = 48
+	#Max range for Extruder Mk2
+	#Range: > 1
+	extruder2MaxRange = 64
+	#Max range for Extruder Mk1
+	#Range: > 1
+	extruder1MaxRange = 32
+	#Base range for Sender Mk1 (no range upgrades)
+	#Range: > 1
+	sender1BaseRange = 8
+	#Max range for Sender Mk1
+	#Range: > 1
+	sender1MaxRange = 16
+	#Should Sender modules show particle effects when working?
+	senderParticles = true
+	#Should Vacuum modules show particle effects when working?
+	vacuumParticles = true
+	#Should Extruder Mk1/2 modules play a sound when placing/removing blocks?
+	extruderSound = true
+	#Max range for Vacuum
+	#Range: > 1
+	vacuumMaxRange = 12
+	#Base range for Vacuum (no range upgrades)
+	#Range: > 1
+	vacuumBaseRange = 6
+	#Max range for Puller Mk2
+	#Range: > 1
+	puller2MaxRange = 24
+	#Should Placer modules show particle effects when working?
+	placerParticles = true
+	#Base range for Extruder Mk1 (no range upgrades)
+	#Range: > 1
+	extruder1BaseRange = 16
+	#Should Flinger modules show smoke effects & play a sound when working?
+	flingerEffects = true
+	#Should Extruder Mk1/2 modules push entities along when extruding blocks?
+	extruderPushEntities = true
+	#Should Breaker & Extruder Mk1 Modules respect the harvest level of the pickaxe used to craft them? (e.g. craft with an Iron Pickaxe => can't break Obsidian
+	breakerHarvestLevelLimit = true
+	#Base range for Extruder Mk2 (no range upgrades)
+	#Range: > 1
+	extruder2BaseRange = 32
+	#Base range for Fluid Mk2 (no range upgrades)
+	#Range: > 1
+	fluid2BaseRange = 12
+	#Should Puller modules show particle effects when working?
+	pullerParticles = true
+	#Max range for Fluid Mk2
+	#Range: > 1
+	fluid2MaxRange = 24
+	#List of entity types which the Activator Module (in entity mode) should never attempt to interact with. Any entity which opens a GUI when right-clicked, like Villagers, should be added here, especially if it prevents player interaction.
+	activatorEntityBlacklist = ["minecraft:villager", "minecraft:wandering_trader"]
+
+[Router]
+	#Hard minimum tick interval for a router regardless of Speed Upgrades
+	#Range: > 1
+	hardMinTickRate = 2
+	#Number of ticks by which 1 Speed Upgrade will reduce the router's tick interval
+	#Range: > 1
+	ticksPerUpgrade = 2
+	#Tick interval for an eco-mode router which has gone into low-power mode
+	#Range: > 1
+	lowPowerTickRate = 100
+	#Fluid transfer rate increase per Fluid Transfer Upgrade
+	#Range: > 1
+	mBperFluidUpgade = 10
+	#Base fluid transfer rate (mB/t in each direction) for a router
+	#Range: > 1
+	fluidBaseTransferRate = 50
+	#Router with eco mode enabled will go into low-power mode if idle for this many server ticks
+	#Range: > 1
+	ecoTimeout = 100
+	#Base tick interval (in server ticks) for a router; router will run this often
+	#Range: > 1
+	baseTickRate = 20
+	#Max fluid transfer rate (mB/t in each direction) for a router
+	#Range: > 1
+	fluidMaxTransferRate = 400
+	#FE capacity per Energy Upgrade
+	#Range: > 1
+	fePerEnergyUpgrade = 2000000
+	#FE transfer rate (FE/t) per Energy Upgrade
+	#Range: > 1
+	feXferPerEnergyUpgrade = 20000
+	#Should block-breaking modules drop XP where appropriate? (ore mining etc.)
+	blockBreakXPDrops = true
+
+["Energy Costs"]
+	#Energy cost (FE) to run one right-click operation for the Activator Module
+	#Range: > 0
+	activatorModuleEnergyCost = 0
+	#Energy cost (FE) to run one left-click (attack) operation for the Activator Module
+	#Range: > 0
+	activatorModuleEnergyCostAttack = 150
+	#Energy cost (FE) to run one operation for the Breaker Module
+	#Range: > 0
+	breakerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Detector Module
+	#Range: > 0
+	detectorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Distributor Module
+	#Range: > 0
+	distributorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Dropper Module
+	#Range: > 0
+	dropperModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Energy Distributor Module
+	#Range: > 0
+	energydistributorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Energy Output Module
+	#Range: > 0
+	energyoutputModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Extruder Module Mk1
+	#Range: > 0
+	extruderModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Extruder Module Mk2
+	#Range: > 0
+	extruderModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Flinger Module
+	#Range: > 0
+	flingerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Fluid Module Mk1
+	#Range: > 0
+	fluidModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Fluid Module Mk2
+	#Range: > 0
+	fluidModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Placer Module
+	#Range: > 0
+	placerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Player Module
+	#Range: > 0
+	playerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Puller Module Mk1
+	#Range: > 0
+	pullerModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Puller Module Mk2
+	#Range: > 0
+	pullerModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk1
+	#Range: > 0
+	senderModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk2
+	#Range: > 0
+	senderModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk3
+	#Range: > 0
+	senderModule3EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Vacuum Module
+	#Range: > 0
+	vacuumModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Void Module
+	#Range: > 0
+	voidModuleEnergyCost = 0
+

--- a/config/configswapper/normal/config/modularrouters-common.toml
+++ b/config/configswapper/normal/config/modularrouters-common.toml
@@ -1,0 +1,167 @@
+
+[Module]
+	#Should Breaker modules show particle effects when working?
+	breakerParticles = true
+	#Base range for Puller Mk2 (no range upgrades)
+	#Range: > 1
+	puller2BaseRange = 12
+	#Base range for Sender Mk2 (no range upgrades)
+	#Range: > 1
+	sender2BaseRange = 24
+	#Max range for Sender Mk2
+	#Range: > 1
+	sender2MaxRange = 48
+	#Max range for Extruder Mk2
+	#Range: > 1
+	extruder2MaxRange = 64
+	#Max range for Extruder Mk1
+	#Range: > 1
+	extruder1MaxRange = 32
+	#Base range for Sender Mk1 (no range upgrades)
+	#Range: > 1
+	sender1BaseRange = 8
+	#Max range for Sender Mk1
+	#Range: > 1
+	sender1MaxRange = 16
+	#Should Sender modules show particle effects when working?
+	senderParticles = true
+	#Should Vacuum modules show particle effects when working?
+	vacuumParticles = true
+	#Should Extruder Mk1/2 modules play a sound when placing/removing blocks?
+	extruderSound = true
+	#Max range for Vacuum
+	#Range: > 1
+	vacuumMaxRange = 12
+	#Base range for Vacuum (no range upgrades)
+	#Range: > 1
+	vacuumBaseRange = 6
+	#Max range for Puller Mk2
+	#Range: > 1
+	puller2MaxRange = 24
+	#Should Placer modules show particle effects when working?
+	placerParticles = true
+	#Base range for Extruder Mk1 (no range upgrades)
+	#Range: > 1
+	extruder1BaseRange = 16
+	#Should Flinger modules show smoke effects & play a sound when working?
+	flingerEffects = true
+	#Should Extruder Mk1/2 modules push entities along when extruding blocks?
+	extruderPushEntities = true
+	#Should Breaker & Extruder Mk1 Modules respect the harvest level of the pickaxe used to craft them? (e.g. craft with an Iron Pickaxe => can't break Obsidian
+	breakerHarvestLevelLimit = true
+	#Base range for Extruder Mk2 (no range upgrades)
+	#Range: > 1
+	extruder2BaseRange = 32
+	#Base range for Fluid Mk2 (no range upgrades)
+	#Range: > 1
+	fluid2BaseRange = 12
+	#Should Puller modules show particle effects when working?
+	pullerParticles = true
+	#Max range for Fluid Mk2
+	#Range: > 1
+	fluid2MaxRange = 24
+	#List of entity types which the Activator Module (in entity mode) should never attempt to interact with. Any entity which opens a GUI when right-clicked, like Villagers, should be added here, especially if it prevents player interaction.
+	activatorEntityBlacklist = ["minecraft:villager", "minecraft:wandering_trader"]
+
+[Router]
+	#Hard minimum tick interval for a router regardless of Speed Upgrades
+	#Range: > 1
+	hardMinTickRate = 2
+	#Number of ticks by which 1 Speed Upgrade will reduce the router's tick interval
+	#Range: > 1
+	ticksPerUpgrade = 2
+	#Tick interval for an eco-mode router which has gone into low-power mode
+	#Range: > 1
+	lowPowerTickRate = 100
+	#Fluid transfer rate increase per Fluid Transfer Upgrade
+	#Range: > 1
+	mBperFluidUpgade = 10
+	#Base fluid transfer rate (mB/t in each direction) for a router
+	#Range: > 1
+	fluidBaseTransferRate = 50
+	#Router with eco mode enabled will go into low-power mode if idle for this many server ticks
+	#Range: > 1
+	ecoTimeout = 100
+	#Base tick interval (in server ticks) for a router; router will run this often
+	#Range: > 1
+	baseTickRate = 20
+	#Max fluid transfer rate (mB/t in each direction) for a router
+	#Range: > 1
+	fluidMaxTransferRate = 400
+	#FE capacity per Energy Upgrade
+	#Range: > 1
+	fePerEnergyUpgrade = 50000
+	#FE transfer rate (FE/t) per Energy Upgrade
+	#Range: > 1
+	feXferPerEnergyUpgrade = 1000
+	#Should block-breaking modules drop XP where appropriate? (ore mining etc.)
+	blockBreakXPDrops = true
+
+["Energy Costs"]
+	#Energy cost (FE) to run one right-click operation for the Activator Module
+	#Range: > 0
+	activatorModuleEnergyCost = 0
+	#Energy cost (FE) to run one left-click (attack) operation for the Activator Module
+	#Range: > 0
+	activatorModuleEnergyCostAttack = 150
+	#Energy cost (FE) to run one operation for the Breaker Module
+	#Range: > 0
+	breakerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Detector Module
+	#Range: > 0
+	detectorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Distributor Module
+	#Range: > 0
+	distributorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Dropper Module
+	#Range: > 0
+	dropperModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Energy Distributor Module
+	#Range: > 0
+	energydistributorModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Energy Output Module
+	#Range: > 0
+	energyoutputModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Extruder Module Mk1
+	#Range: > 0
+	extruderModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Extruder Module Mk2
+	#Range: > 0
+	extruderModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Flinger Module
+	#Range: > 0
+	flingerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Fluid Module Mk1
+	#Range: > 0
+	fluidModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Fluid Module Mk2
+	#Range: > 0
+	fluidModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Placer Module
+	#Range: > 0
+	placerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Player Module
+	#Range: > 0
+	playerModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Puller Module Mk1
+	#Range: > 0
+	pullerModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Puller Module Mk2
+	#Range: > 0
+	pullerModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk1
+	#Range: > 0
+	senderModule1EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk2
+	#Range: > 0
+	senderModule2EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Sender Module Mk3
+	#Range: > 0
+	senderModule3EnergyCost = 0
+	#Energy cost (FE) to run one operation for the Vacuum Module
+	#Range: > 0
+	vacuumModuleEnergyCost = 0
+	#Energy cost (FE) to run one operation for the Void Module
+	#Range: > 0
+	voidModuleEnergyCost = 0
+

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -94,6 +94,8 @@ onEvent('recipes', (event) => {
 
         'mininggadgets:upgrade_empty',
 
+        'modularrouters:energy_upgrade',
+
         'pedestals:ingot_gold_from_upgrades',
         'pedestals:upgrades/breaker2',
         'pedestals:upgrades/crafter1mk2',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/arc_furnace.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/arc_furnace.js
@@ -28,11 +28,53 @@ onEvent('recipes', (event) => {
                 secondaries: [['#forge:dusts/coal_petcoke', '#forge:dusts/coal_coke']],
                 outputs: [Item.of('8x industrialforegoing:plastic'), Item.of('8x thermal:slag')],
                 id: `${id_prefix}plastic`
+            },
+            {
+                input1: Item.of(Item.of('powah:energizing_rod_basic').ignoreNBT()),
+                secondaries: ['mekanismgenerators:laser_focus_matrix', Item.of('4x modularrouters:blank_upgrade')],
+                outputs: [Item.of('4x modularrouters:energy_upgrade')],
+                time: 100 * 4,
+                energy: 51200 * 4,
+                id: `${id_prefix}energy_upgrade_from_energizing_rod_basic`
+            },
+            {
+                input1: Item.of(Item.of('powah:energizing_rod_hardened').ignoreNBT()),
+                secondaries: ['mekanismgenerators:laser_focus_matrix', Item.of('10x modularrouters:blank_upgrade')],
+                outputs: [Item.of('10x modularrouters:energy_upgrade')],
+                time: 100 * 10,
+                energy: 51200 * 10,
+                id: `${id_prefix}energy_upgrade_from_energizing_rod_hardened`
+            },
+            {
+                input1: Item.of(Item.of('powah:energizing_rod_blazing').ignoreNBT()),
+                secondaries: ['mekanismgenerators:laser_focus_matrix', Item.of('34x modularrouters:blank_upgrade')],
+                outputs: [Item.of('34x modularrouters:energy_upgrade')],
+                time: 100 * 34,
+                energy: 51200 * 34,
+                id: `${id_prefix}energy_upgrade_from_energizing_rod_blazing`
+            },
+            {
+                input1: Item.of(Item.of('powah:energizing_rod_niotic').ignoreNBT()),
+                secondaries: ['mekanismgenerators:laser_focus_matrix', Item.of('64x modularrouters:blank_upgrade')],
+                outputs: [Item.of('64x modularrouters:energy_upgrade')],
+                time: 100 * 64,
+                energy: 51200 * 64,
+                id: `${id_prefix}energy_upgrade_from_energizing_rod_niotic`
             }
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        event.recipes.immersiveengineering.arc_furnace(recipe.outputs, recipe.input1, recipe.secondaries).id(recipe.id);
+        const re = event.recipes.immersiveengineering
+            .arc_furnace(recipe.outputs, recipe.input1, recipe.secondaries)
+            .id(recipe.id);
+
+        if (recipe.time) {
+            re.time(recipe.time);
+        }
+
+        if (recipe.energy) {
+            re.energy(recipe.energy);
+        }
     });
 });


### PR DESCRIPTION
Aim here is to make Routers viable again for powering IF Laser Drill arrays. With this buff, a router can pretty comfortably power a 3x3x3 cube of lasers, assuming it has full power/speed upgrades. 

Also alters the recipe to be later game as a result. 

![image](https://user-images.githubusercontent.com/9543430/149862594-a5450155-a80e-48b8-ab3a-8635eacd75b2.png)
