### PR TITLE
Make nbt extracters not require the programmer

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
@@ -108,6 +108,16 @@ onEvent('recipes', (event) => {
             filter: { id: 'botania:spectral_platform' },
             toReplace: 'botania:pixie_dust',
             replaceWith: 'atum:ectoplasm'
+        },
+		{
+            filter: { id: 'integratednbt:nbt_extractor' },
+            toReplace: 'integrateddynamics:logic_programmer',
+            replaceWith: 'integrateddynamics:variable_transformer_input'
+        },
+		{
+            filter: { id: 'integratednbt:nbt_extractor_remote' },
+            toReplace: 'integrateddynamics:logic_programmer',
+            replaceWith: 'integrateddynamics:variable_transformer_input'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -242,7 +242,7 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'integrateddynamics:logic_programmer',
-            pattern: ['ABBBA', 'CDEDC', 'CFGFC', 'CHIHC', 'ABBBA'],
+            pattern: ['ABBBA', 'CDEDC', 'CFGFC', 'CIHJC', 'ABBBA'],
             key: {
                 A: 'pneumaticcraft:logistics_core',
                 B: 'integrateddynamics:crystalized_menril_block',
@@ -252,7 +252,8 @@ onEvent('recipes', (event) => {
                 F: 'pneumaticcraft:smart_chest',
                 G: 'refinedstorage:machine_casing',
                 H: 'pneumaticcraft:upgrade_matrix',
-                I: 'pneumaticcraft:remote'
+                I: 'pneumaticcraft:network_io_port',
+				J: 'pneumaticcraft:network_data_storage'
             },
             id: 'integrateddynamics:crafting/logic_programmer'
         },


### PR DESCRIPTION
The programmer is a lot more expensive in Expert, so using it as a crafting ingredient for a QOL item is maybe a bit much. In normal mode, the programmer is fine as an ingredient as it's trivial to make, and that's what the vanilla nbt extractor recipes are balanced around. Replaced with an input variable transformer, as the block 'reads' the card you insert.

Could instead be a 'network reader' to add some cables to the cost, and may be more thematic?