### PR TITLE
[Expert] Revert IE Crusher speed upgrade

### DIFF
--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -42,7 +42,7 @@
 	energyModifier = 25.6
 	#A modifier to apply to the time of every crusher recipe
 	#Range: 0.001 ~ 1000.0
-	timeModifier = 0.05
+	timeModifier = 0.1
 
 [machines.squeezer]
 	#A modifier to apply to the energy costs of every squeezer recipe


### PR DESCRIPTION
Revert speed change as it makes the machine incapable of running (buffer too small for energy per tick). Messed around with some different values and ultimately decided that it probably doesn't need to be faster than Create since it outputs more. 