### PR TITLE
Add pre-genned NBT to thermal cells, fixes RS autocrafting with them.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_output.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_output.js
@@ -1,0 +1,23 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            replaceTarget: { id: 'thermal:fluid_cell' },
+            toReplace: 'thermal:fluid_cell',
+            replaceWith: Item.of('thermal:fluid_cell', '{BlockEntityTag:{TankInv:[{FluidName:"minecraft:empty",Capacity:32000,Tank:0b,Amount:0}]}}')
+        },
+		{
+            replaceTarget: { id: 'thermal:energy_cell' },
+            toReplace: 'thermal:energy_cell',
+            replaceWith: Item.of('thermal:energy_cell', '{BlockEntityTag:{EnergyMax:1000000,EnergySend:1000,Energy:0,EnergyRecv:1000}}')
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.replaceOutput(recipe.replaceTarget, recipe.toReplace, recipe.replaceWith);
+    });
+
+});


### PR DESCRIPTION
Adding the NBT from a newly crafted thermal cell to the default output for thermal cells stops RS autocrafting getting really confused. Just re-encode your patterns for the energy and fluid cells after updating.

This is in the kube expert branch as I don't think normal mode has anything that uses crafted thermal cells as inputs? Could go in kube base branch instead though without hurting anything, if the `if (global.isExpertMode == false)` conditional was removed.