### PR TITLE
PP module clearing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/prettypipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/prettypipes/shapeless.js
@@ -1,7 +1,8 @@
 onEvent('recipes', (event) => {
+	const id_prefix = 'enigmatica:base/prettypipes/shapeless/';
     const moduletype = ['prettypipes:low_extraction_module', 'prettypipes:medium_extraction_module', 'prettypipes:high_extraction_module', 'prettypipes:low_filter_module', 'prettypipes:medium_filter_module', 'prettypipes:high_filter_module', 'prettypipes:low_retrieval_module', 'prettypipes:medium_retrieval_module', 'prettypipes:high_retrieval_module', 'prettypipes:low_crafting_module', 'prettypipes:medium_crafting_module', 'prettypipes:high_crafting_module', 'prettypipes:stack_size_module', 'prettypipes:filter_increase_modifier','ppfluids:low_fluid_extraction_module', 'ppfluids:medium_fluid_extraction_module', 'ppfluids:high_fluid_extraction_module', 'ppfluids:low_fluid_filter_module', 'ppfluids:medium_fluid_filter_module', 'ppfluids:high_fluid_filter_module', 'ppfluids:low_fluid_retrieval_module', 'ppfluids:medium_fluid_retrieval_module', 'ppfluids:high_fluid_retrieval_module'];
 
     moduletype.forEach((module) => {
-        event.shapeless(module, [Item.of(module).ignoreNBT()]).id(module+'_clear');
+        event.shapeless(module, [Item.of(module).ignoreNBT()]).id(`${id_prefix}${module.split(':')[1]}_clearnbt`);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/prettypipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/prettypipes/shapeless.js
@@ -1,0 +1,7 @@
+onEvent('recipes', (event) => {
+    const moduletype = ['prettypipes:low_extraction_module', 'prettypipes:medium_extraction_module', 'prettypipes:high_extraction_module', 'prettypipes:low_filter_module', 'prettypipes:medium_filter_module', 'prettypipes:high_filter_module', 'prettypipes:low_retrieval_module', 'prettypipes:medium_retrieval_module', 'prettypipes:high_retrieval_module', 'prettypipes:low_crafting_module', 'prettypipes:medium_crafting_module', 'prettypipes:high_crafting_module', 'prettypipes:stack_size_module', 'prettypipes:filter_increase_modifier','ppfluids:low_fluid_extraction_module', 'ppfluids:medium_fluid_extraction_module', 'ppfluids:high_fluid_extraction_module', 'ppfluids:low_fluid_filter_module', 'ppfluids:medium_fluid_filter_module', 'ppfluids:high_fluid_filter_module', 'ppfluids:low_fluid_retrieval_module', 'ppfluids:medium_fluid_retrieval_module', 'ppfluids:high_fluid_retrieval_module'];
+
+    moduletype.forEach((module) => {
+        event.shapeless(module, [Item.of(module).ignoreNBT()]).id(module+'_clear');
+    });
+});


### PR DESCRIPTION
Added nbt clearing shapeless recipes for Pretty Pipes/Pretty Fluid Pipes modules. Saves having to manually clear them by inserting them into an in-world pipe attached to an inventory block.

Eg (input side has ignoreNBT tag):
![image](https://user-images.githubusercontent.com/2611674/150389949-0bc3fb53-f5f0-425c-b03e-56f21438e073.png)

![image](https://user-images.githubusercontent.com/2611674/150389976-4adcce32-9928-4e85-9791-21aa86c05242.png)
