### PR TITLE
Added Quark deepslate and new Ars stones to stonecutter

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -191,7 +191,7 @@ onEvent('jei.information', (event) => {
             text: ['Place next to living coral to infuse.']
         },
         {
-            items: [/quark:\w+_crystal$/],
+            items: ['#quark:crystal'],
             text: [
                 'Will grow up to four blocks tall if placed deep underground. Will emit particles while growing.',
                 ' ',

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -191,7 +191,7 @@ onEvent('jei.information', (event) => {
             text: ['Place next to living coral to infuse.']
         },
         {
-            items: ['#quark:crystal'],
+            items: [/quark:\w+_crystal$/],
             text: [
                 'Will grow up to four blocks tall if placed deep underground. Will emit particles while growing.',
                 ' ',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -189,7 +189,13 @@ const stonecuttables = [
             'ars_nouveau:ab_mosaic',
             'ars_nouveau:ab_herring',
             'ars_nouveau:ab_basket',
-            'ars_nouveau:ab_alternating'
+            'ars_nouveau:ab_alternating',
+            'ars_nouveau:sas_basket',
+            'ars_nouveau:sas_clover',
+            'ars_nouveau:sas_herring',
+            'ars_nouveau:sas_mosaic',
+            'ars_nouveau:sas_alternating',
+            'ars_nouveau:sas_ashlar'
         ],
         onlyAsOutput: [],
         onlyAsInput: []
@@ -1723,6 +1729,20 @@ const stonecuttables = [
         ],
         onlyAsOutput: [],
         onlyAsInput: []
+    },
+	{
+        name: 'deepslate',
+        stones: [
+            'quark:cobbled_deepslate',
+            'quark:polished_deepslate',
+            'quark:deepslate_bricks',
+            'quark:deepslate_tiles',
+            'quark:chiseled_deepslate',
+            'quark:cracked_deepslate_bricks',
+            'quark:cracked_deepslate_tiles'
+        ],
+        onlyAsOutput: [],
+        onlyAsInput: ['quark:deepslate']
     },
     {
         name: 'soapstone',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -1034,6 +1034,20 @@ const stonecuttables = [
         onlyAsInput: []
     },
     {
+        name: 'marblesooty',
+        stones: [
+            'astralsorcery:black_marble_raw',
+            'astralsorcery:black_marble_runed',
+            'astralsorcery:black_marble_pillar',
+            'astralsorcery:black_marble_arch',
+            'astralsorcery:black_marble_bricks',
+            'astralsorcery:black_marble_chiseled',
+            'astralsorcery:black_marble_engraved'
+        ],
+        onlyAsOutput: [],
+        onlyAsInput: []
+    },
+    {
         name: 'metamorphic_desert_stone',
         stones: [
             'botania:metamorphic_desert_stone',


### PR DESCRIPTION
Added Quark deepslate and the new Ars "smooth" arcane stones to stonecutter:
![image](https://user-images.githubusercontent.com/2611674/150617346-29c5ad13-da0b-4215-a3ca-730a6962e217.png)
![image](https://user-images.githubusercontent.com/2611674/150617330-781968fd-aefa-47be-9ff2-f197547dc622.png)

Also minor info tab fix for corundum, which was getting applied to irrelevant items.