### PR TITLE
Add more BYG mushrooms to the market

### DIFF
--- a/kubejs/data/farmingforblockheads/farmingforblockheads_compat/byg_saplings.json
+++ b/kubejs/data/farmingforblockheads/farmingforblockheads_compat/byg_saplings.json
@@ -58,6 +58,12 @@
         { "output": { "item": "byg:red_glowcane" } },
         { "output": { "item": "byg:purple_glowcane" } },
         { "output": { "item": "byg:pink_glowcane" } },
-        { "output": { "item": "byg:blue_glowcane" } }
+        { "output": { "item": "byg:blue_glowcane" } },
+        { "output": { "item": "byg:sythian_fungus" } },
+        { "output": { "item": "byg:soul_shroom" } },
+        { "output": { "item": "byg:embur_wart" } },
+        { "output": { "item": "byg:purple_glowshroom" } },
+        { "output": { "item": "byg:blue_glowshroom" } },
+        { "output": { "item": "byg:shulkren_fungus" } }
     ]
 }


### PR DESCRIPTION
Add some mushrooms from BYG to the market place, as many produce either shroomlights or materials for crafts but are missing since nether biomes were removed. 