### PR TITLE
[Expert] Shuffle a few machines around on the Machinery Schematics

### DIFF
--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -80,7 +80,7 @@
 [machines]
 	#The Flux that will be output by the lightning rod when it is struck
 	#Range: > 0
-	lightning_output = 2147483647
+	lightning_output = 1073741824
 	#The Flux per tick that the Diesel Generator will output. The burn time of the fuel determines the total output
 	#Range: > 0
 	dieselGen_output = 16384

--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -78,6 +78,9 @@
 		maxLength = 32
 
 [machines]
+	#The Flux that will be output by the lightning rod when it is struck
+	#Range: > 0
+	lightning_output = 2147483647
 	#The Flux per tick that the Diesel Generator will output. The burn time of the fuel determines the total output
 	#Range: > 0
 	dieselGen_output = 16384

--- a/kubejs/client_scripts/expert/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/expert/item_modifiers/tooltips.js
@@ -48,6 +48,35 @@ onEvent('item.tooltip', (event) => {
                 Text.of('Liquid Meat can be obtained by "processing" cows.').color('#6e2a2a'),
                 Text.of('Pink Slime can be harvested from a Pink Wither using a Fluid Laser.').color('#da07e6')
             ]
+        },
+        {
+            items: ['kubejs:medium_machinery_schematics'],
+            text: [
+                Text.of(`Unlocks the ability to form the following strutures:`).blue(),
+                Text.of(`- Diesel Generator`).aqua(),
+                Text.of(`- Excavator`).aqua(),
+                Text.of(`- Fermenter`).aqua(),
+                Text.of(`- Metal Press`).aqua(),
+                Text.of(`- Mixer`).aqua(),
+                Text.of(`- Pumpjack`).aqua(),
+                Text.of(`- Refinery`).aqua(),
+                Text.of(`- Sawmill`).aqua(),
+                Text.of(`- Squeezer`).aqua()
+            ]
+        },
+        {
+            items: ['kubejs:heavy_machinery_schematics'],
+            text: [
+                Text.of(`Unlocks the ability to form the following strutures:`).blue(),
+                Text.of(`- Arc Furnace`).aqua(),
+                Text.of(`- Assembler`).aqua(),
+                Text.of(`- Automated Engineer's Workbench`).aqua(),
+                Text.of(`- Coker Unit`).aqua(),
+                Text.of(`- Crusher`).aqua(),
+                Text.of(`- Distillation Tower`).aqua(),
+                Text.of(`- Lightning Rod`).aqua(),
+                Text.of(`- Sulfur Recovery Unit`).aqua()
+            ]
         }
     ];
 

--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -149,35 +149,6 @@ onEvent('item.tooltip', (event) => {
             ]
         },
         {
-            items: ['kubejs:medium_machinery_schematics'],
-            text: [
-                Text.of(`Unlocks the ability to form the following strutures in Expert:`).blue(),
-                Text.of(`- Diesel Generator`).aqua(),
-                Text.of(`- Excavator`).aqua(),
-                Text.of(`- Lightning Rod`).aqua(),
-                Text.of(`- Metal Press`).aqua(),
-                Text.of(`- Mixer`).aqua(),
-                Text.of(`- Pumpjack`).aqua(),
-                Text.of(`- Sawmill`).aqua(),
-                Text.of(`- Squeezer`).aqua()
-            ]
-        },
-        {
-            items: ['kubejs:heavy_machinery_schematics'],
-            text: [
-                Text.of(`Unlocks the ability to form the following strutures in Expert:`).blue(),
-                Text.of(`- Arc Furnace`).aqua(),
-                Text.of(`- Assembler`).aqua(),
-                Text.of(`- Automated Engineer's Workbench`).aqua(),
-                Text.of(`- Coker Unit`).aqua(),
-                Text.of(`- Crusher`).aqua(),
-                Text.of(`- Distillation Tower`).aqua(),
-                Text.of(`- Fermenter`).aqua(),
-                Text.of(`- Refinery`).aqua(),
-                Text.of(`- Sulfur Recovery Unit`).aqua()
-            ]
-        },
-        {
             items: [/natures\w+:\w+_generator/],
             text: [Text.of(`Aura Generator`).green()]
         },

--- a/kubejs/startup_scripts/multiblock_gamestages.js
+++ b/kubejs/startup_scripts/multiblock_gamestages.js
@@ -1,4 +1,4 @@
-onEvent('ie.multiblock.form', event => {
+onEvent('ie.multiblock.form', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
@@ -10,32 +10,32 @@ onEvent('ie.multiblock.form', event => {
         ['immersiveengineering:multiblocks/excavator_full', 'medium_machinery_schematics'],
         ['immersiveengineering:multiblocks/mixer', 'medium_machinery_schematics'],
         ['immersiveengineering:multiblocks/sawmill', 'medium_machinery_schematics'],
-        ['immersiveengineering:multiblocks/squeezer', 'medium_machinery_schematics'],
-        ['immersiveengineering:multiblocks/lightning_rod', 'medium_machinery_schematics'],
         ['immersiveengineering:multiblocks/metal_press', 'medium_machinery_schematics'],
         ['immersiveengineering:multiblocks/diesel_generator', 'medium_machinery_schematics'],
+        ['immersiveengineering:multiblocks/refinery', 'medium_machinery_schematics'],
+        ['immersiveengineering:multiblocks/fermenter', 'medium_machinery_schematics'],
+        ['immersiveengineering:multiblocks/squeezer', 'medium_machinery_schematics'],
 
         ['immersiveengineering:multiblocks/auto_workbench', 'heavy_machinery_schematics'],
         ['immersiveengineering:multiblocks/arcfurnace', 'heavy_machinery_schematics'],
         ['immersiveengineering:multiblocks/assembler', 'heavy_machinery_schematics'],
         ['immersiveengineering:multiblocks/crusher', 'heavy_machinery_schematics'],
-        ['immersiveengineering:multiblocks/refinery', 'heavy_machinery_schematics'],
-        ['immersiveengineering:multiblocks/fermenter', 'heavy_machinery_schematics'],
         ['immersivepetroleum:multiblocks/cokerunit', 'heavy_machinery_schematics'],
         ['immersivepetroleum:multiblocks/distillationtower', 'heavy_machinery_schematics'],
-        ['immersivepetroleum:multiblocks/hydrotreater', 'heavy_machinery_schematics']
+        ['immersivepetroleum:multiblocks/hydrotreater', 'heavy_machinery_schematics'],
+        ['immersiveengineering:multiblocks/lightning_rod', 'heavy_machinery_schematics']
     ]);
 
     const name = `${event.getMultiblock()}`;
     if (requiredGameStage.has(name)) {
         if (!event.getEntity().stages.has(requiredGameStage.get(name))) {
-			event.cancel();
-			if(!event.getEntity().getServer()) {
-				let error_message = `Invalid structure or missing gamestage. Obtain a ${titleCase(
-                   requiredGameStage.get(name).toString().replace(/_/g, ' ')
-               )} to be able to form this multiblock.`;
-               event.getEntity().tell(error_message);
-			}
+            event.cancel();
+            if (!event.getEntity().getServer()) {
+                let error_message = `Invalid structure or missing gamestage. Obtain a ${titleCase(
+                    requiredGameStage.get(name).toString().replace(/_/g, ' ')
+                )} to be able to form this multiblock.`;
+                event.getEntity().tell(error_message);
+            }
         }
     }
 });


### PR DESCRIPTION
Moves Refinery and Squeezer up to be used with the Diesel Gen. Moves Lightning rod to Heavy Machine and pumps up it's max power per lightning. 

This may seem like a massive boost, but over a 3 hour period with random weather, it generated about 36k FE/t with this rate.  If a player were to keep their world in perpetual storms, it gets up to 750k FE/t. 