### PR TITLE
Fixes Blacksmith Familiar quest and modifies Foliot Crusher description

### DIFF
--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -223,11 +223,7 @@
 				""
 				"This spirit will take your ores and chonky chunks and crush crush crush them in to dusts which you can smelt in to ingots."
 				""
-				"Our little spirit friend is very efficient at their job! Each ore/chunk you give it will result in 2 dusts which you can smelt in to ingots effectively doubling your ore count!"
-				""
-				"While it does work hard, staying in this mortal realm is tough on our little friend. After awhile it will need to travel back to the other world where it will rest peacefully until you summon it again. As you progress in your journey, you will be able to summon more powerful crushers without these limitations!"
-				""
-				"Note: You must have a golden sacrificial bowl to continue."
+				"As you progress in your journey, you will be able to summon more powerful crushers!"
 			]
 			dependencies: ["0000000000000DD8"]
 			id: "0000000000000CF7"
@@ -1987,7 +1983,7 @@
 				type: "advancement"
 				title: "Summon Blacksmith Familiar"
 				icon: "minecraft:anvil"
-				advancement: "occultism:occultism/familiar/blacksmith_upgrade"
+				advancement: "occultism:occultism/familiar_blacksmith"
 				criterion: ""
 			}]
 			rewards: [{

--- a/kubejs/data/occultism/advancements/occultism/familiar_blacksmith.json
+++ b/kubejs/data/occultism/advancements/occultism/familiar_blacksmith.json
@@ -1,0 +1,33 @@
+{
+    "parent": "occultism:occultism/root",
+    "display": {
+      "icon": {
+        "item": "occultism:jei_dummy/none"
+      },
+      "title": {
+        "translate": "advancements.occultism.familiar_blacksmith.title"
+      },
+      "description": {
+        "translate": "advancements.occultism.familiar_blacksmith.description"
+      },
+      "frame": "task",
+      "show_toast": false,
+      "announce_to_chat": false,
+      "hidden": true
+    },
+    "criteria": {
+      "familiar_blacksmith": {
+        "trigger": "occultism:ritual",
+        "conditions": {
+          "ritual_predicate": {
+            "ritual_id": "occultism:ritual/familiar_blacksmith"
+          }
+        }
+      }
+    },
+    "requirements": [
+      [
+        "familiar_blacksmith"
+      ]
+    ]
+  }


### PR DESCRIPTION
Fixes #3997 and updates foliot crusher to fit better with expert mode, and removes info about spirit decay and golden bowl dependency.

Datapacked in an advancement for the blacksmith familiar. We can remove this if klikli adds one in occultism, i used the same name scheme so shouldn't effect anything if fixed in the mod