### PR TITLE
Add Backpack XP to conversion recipes.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -23,7 +23,7 @@ onEvent('recipes', (event) => {
 */
         {
             inputs: ['minecraft:glass_pane'],
-            inputFluid: 'pneumaticcraft:memory_essence',
+            inputFluid: 'sophisticatedbackpacks:xp_still',
             inputFluidAmount: 1000,
             processingTime: 50,
             outputItem: { item: 'minecraft:glass_pane', count: 1 },
@@ -46,6 +46,15 @@ onEvent('recipes', (event) => {
             processingTime: 50,
             outputItem: { item: 'minecraft:glass_pane', count: 1 },
             outputFluid: 'pneumaticcraft:memory_essence',
+            outputFluidAmount: 1000
+        },
+        {
+            inputs: ['minecraft:glass_pane'],
+            inputFluid: 'pneumaticcraft:memory_essence',
+            inputFluidAmount: 1000,
+            processingTime: 50,
+            outputItem: { item: 'minecraft:glass_pane', count: 1 },
+            outputFluid: 'sophisticatedbackpacks:xp_still',
             outputFluidAmount: 1000
         },
         {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/thermo_plant.js
@@ -4,12 +4,12 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             type: 'pneumaticcraft:thermo_plant',
-            fluid_input: { type: 'pneumaticcraft:fluid', fluid: 'pneumaticcraft:memory_essence', amount: 1000 },
+            fluid_input: { type: 'pneumaticcraft:fluid', fluid: 'sophisticatedbackpacks:xp_still', amount: 1000 },
             fluid_output: { fluid: 'industrialforegoing:essence', amount: 1000 },
             pressure: 1.0,
             speed: 5.0,
             exothermic: false,
-            id: `${id_prefix}pnc_memory_essence_from_if_essence`
+            id: `${id_prefix}if_memory_essence_from_sbp_essence`
         },
         {
             type: 'pneumaticcraft:thermo_plant',
@@ -28,6 +28,15 @@ onEvent('recipes', (event) => {
             speed: 5.0,
             exothermic: false,
             id: `${id_prefix}pnc_essence_from_cofh_experience`
+        },
+        {
+            type: 'pneumaticcraft:thermo_plant',
+            fluid_input: { type: 'pneumaticcraft:fluid', fluid: 'pneumaticcraft:memory_essence', amount: 1000 },
+            fluid_output: { fluid: 'sophisticatedbackpacks:xp_still', amount: 1000 },
+            pressure: 1.0,
+            speed: 5.0,
+            exothermic: false,
+            id: `${id_prefix}sbp_essence_from_pnc_experience`
         },
         {
             type: 'pneumaticcraft:thermo_plant',


### PR DESCRIPTION
All liquids are 20mB per XP, so should be no issues with adding the new Simple Backpacks liquid to the conversion recipes.