### PR TITLE
[Expert] QoL changes for Compacting upgrades, cleanup on filters used in crafting

### DIFF
--- a/config/guardvillagers-client.toml
+++ b/config/guardvillagers-client.toml
@@ -1,0 +1,3 @@
+#Textures not included, make your own textures by making a resource pack that adds guard_steve_0 - 6
+"Have guards use the steve model?" = false
+

--- a/config/guardvillagers-common.toml
+++ b/config/guardvillagers-common.toml
@@ -1,0 +1,45 @@
+#Illagers In Raids Attack Animals?
+"Illagers in raids attack animals?" = false
+#Witches Attack Villagers?
+"Witches attack villagers?" = true
+#This will make Illusioners get involved in raids
+"Have illusioners in raids?" = true
+#Guards will attack all hostiles with this option
+"Guards attack all mobs?" = false
+#Guards won't attack mobs in this list if AttackAllMobs is enabled, for example, putting minecraft:creeper in this list will make guards ignore creepers.
+"Mob BlackList" = []
+#This makes villagers run from polar bears, as anyone with common sense would.
+"Have Villagers have some common sense?" = true
+#This makes Illagers run from polar bears, as anyone with common sense would.
+"Have Illagers have some common sense?" = true
+#This makes Guards run from polar bears, as anyone with common sense would.
+"Have Guards have some common sense?" = false
+#This lets Guards open doors.
+"Have Guards open doors?" = true
+#This will make guards raise their shields all the time, on default they will only raise their shields under certain conditions
+"Have Guards raise their shield all the time?" = false
+#This makes guards form a phalanx
+"Have guards form a phalanx?" = true
+#This will make guards attempt to avoid friendly fire.
+"Have guards attempt to avoid firing into other friendlies? (Experimental)" = false
+#This will make it so villagers will only be converted into guards if the player has hero of the village
+"Make it so players have to have hero of the village to convert villagers into guards?" = false
+"Have it so blacksmiths heal golems under 60 health?" = true
+"Have it so clerics heal guards and players with hero of the village?" = true
+#This is the range in which the guards will be aggroed to mobs that are attacking villagers. Higher values are more resource intensive, and setting this to zero will disable the goal.
+#Range: -500.0 ~ 500.0
+Range = 50.0
+#Range: -500.0 ~ 500.0
+"Guard Health" = 20.0
+#Range: -500.0 ~ 500.0
+"Guard speed" = 0.5
+#Range: -500.0 ~ 500.0
+"Guard follow range" = 25.0
+#How much health a guard regenerates.
+#Range: -500.0 ~ 500.0
+"Guard health regeneration amount" = 1.0
+"Allow guard arrows to damage villagers, iron golems, or other guards? The i-frames will still be shown for them but they won't lose any health if this is set to false" = true
+"Allow armorers and weaponsmiths repair guard items when down below half durability?" = true
+"Allow players to give guards stuff only if they have the hero of the village effect?" = true
+"Allow players to set guard patrol points only if they have hero of the village" = true
+

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
@@ -429,7 +429,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:gears/osmium',
                 B: 'engineersdecor:factory_hopper',
-                C: 'create:filter',
+                C: '#sophisticatedbackpacks:upgrades/advanced_filter',
                 D: '#industrialforegoing:machine_frame/pity',
                 E: 'pneumaticcraft:advanced_pcb',
                 F: 'thermal:rf_coil'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -1077,7 +1077,7 @@ onEvent('recipes', (event) => {
                 'create:fluid_pipe',
                 '#sophisticatedbackpacks:upgrades/pump',
                 'create:fluid_pipe',
-                'create:attribute_filter'
+                '#sophisticatedbackpacks:upgrades/advanced_filtee'
             ],
             result: 'sophisticatedbackpacks:advanced_pump_upgrade',
             id: `${id_prefix}advanced_pump_upgrade`
@@ -1093,7 +1093,7 @@ onEvent('recipes', (event) => {
                 'create:fluid_pipe',
                 '#sophisticatedbackpacks:upgrades/pump',
                 'create:fluid_pipe',
-                'create:filter',
+                '#sophisticatedbackpacks:upgrades/filter',
                 'ars_nouveau:greater_experience_gem',
                 'ars_nouveau:greater_experience_gem',
                 'ars_nouveau:greater_experience_gem'
@@ -1125,9 +1125,9 @@ onEvent('recipes', (event) => {
             duration: 120,
             ritual_dummy: 'kubejs:craft_advanced_compacting_upgrade',
             ingredients: [
-                '#sophisticatedbackpacks:upgrades/compacting',
+                '#sophisticatedbackpacks:upgrades/crafting',
                 'create:precision_mechanism',
-                'create:attribute_filter',
+                '#sophisticatedbackpacks:upgrades/advanced_filter',
                 'create:precision_mechanism',
                 '#forge:gears/lumium',
                 '#forge:gears/lumium',
@@ -1163,7 +1163,7 @@ onEvent('recipes', (event) => {
             ingredients: [
                 '#sophisticatedbackpacks:upgrades/tool_swapper',
                 'create:precision_mechanism',
-                'create:attribute_filter',
+                '#sophisticatedbackpacks:upgrades/advanced_filter',
                 'create:precision_mechanism',
                 '#forge:gears/lumium',
                 '#forge:gears/lumium',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -1077,7 +1077,7 @@ onEvent('recipes', (event) => {
                 'create:fluid_pipe',
                 '#sophisticatedbackpacks:upgrades/pump',
                 'create:fluid_pipe',
-                '#sophisticatedbackpacks:upgrades/advanced_filtee'
+                '#sophisticatedbackpacks:upgrades/advanced_filter'
             ],
             result: 'sophisticatedbackpacks:advanced_pump_upgrade',
             id: `${id_prefix}advanced_pump_upgrade`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/sophisticatedbackpacks/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/sophisticatedbackpacks/shaped.js
@@ -17,13 +17,13 @@ onEvent('recipes', (event) => {
 
     const recipes = [
         {
-            output: 'sophisticatedbackpacks:upgrade_base',
+            output: '#sophisticatedbackpacks:upgrades/base',
             pattern: ['AAA', 'ABA', 'AAA'],
             key: {
                 A: 'kubejs:scented_stick',
                 B: 'farmersdelight:canvas'
             },
-            id: 'sophisticatedbackpacks:upgrade_base'
+            id: '#sophisticatedbackpacks:upgrades/base'
         },
         {
             output: 'sophisticatedbackpacks:backpack',
@@ -41,7 +41,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:ingots/pig_iron',
                 B: 'immersiveengineering:hemp_fabric',
-                C: 'sophisticatedbackpacks:upgrade_base'
+                C: '#sophisticatedbackpacks:upgrades/base'
             },
             id: 'sophisticatedbackpacks:stack_upgrade_tier_1'
         },
@@ -51,7 +51,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:storage_blocks/rose_gold',
                 B: 'thermal:hazmat_fabric',
-                D: 'sophisticatedbackpacks:stack_upgrade_tier_1'
+                D: '#sophisticatedbackpacks:upgrades/stack_tier_1'
             },
             id: 'sophisticatedbackpacks:stack_upgrade_tier_2'
         },
@@ -61,7 +61,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:storage_blocks/enderium',
                 B: 'thermal:diving_fabric',
-                D: 'sophisticatedbackpacks:stack_upgrade_tier_2'
+                D: '#sophisticatedbackpacks:upgrades/stack_tier_2'
             },
             id: 'sophisticatedbackpacks:stack_upgrade_tier_3'
         },
@@ -71,7 +71,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:storage_blocks/aeternium',
                 B: 'botania:manaweave_cloth',
-                D: 'sophisticatedbackpacks:stack_upgrade_tier_3'
+                D: '#sophisticatedbackpacks:upgrades/stack_tier_3'
             },
             id: 'sophisticatedbackpacks:stack_upgrade_tier_4'
         },
@@ -82,7 +82,7 @@ onEvent('recipes', (event) => {
                 A: 'create:precision_mechanism',
                 B: 'create:crafting_blueprint',
                 C: 'minecraft:barrel',
-                D: 'sophisticatedbackpacks:upgrade_base'
+                D: '#sophisticatedbackpacks:upgrades/base'
             },
             id: 'sophisticatedbackpacks:crafting_upgrade'
         },
@@ -93,7 +93,7 @@ onEvent('recipes', (event) => {
                 A: '#forge:slimeballs',
                 B: 'thermal:redstone_servo',
                 C: 'aquaculture:diamond_fishing_rod',
-                D: 'sophisticatedbackpacks:upgrade_base'
+                D: '#sophisticatedbackpacks:upgrades/base'
             },
             id: 'sophisticatedbackpacks:pickup_upgrade'
         },
@@ -103,7 +103,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:ingots/iron',
                 B: 'bloodmagic:reagentmagnetism',
-                C: 'sophisticatedbackpacks:pickup_upgrade'
+                C: '#sophisticatedbackpacks:upgrades/pickup'
             },
             id: 'sophisticatedbackpacks:magnet_upgrade'
         },
@@ -113,7 +113,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:ingots/iron',
                 B: 'bloodmagic:reagentmagnetism',
-                C: 'sophisticatedbackpacks:advanced_pickup_upgrade'
+                C: '#sophisticatedbackpacks:upgrades/advanced_pickup'
             },
             id: 'sophisticatedbackpacks:advanced_magnet_upgrade'
         },
@@ -123,7 +123,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'naturesaura:hopper_upgrade',
                 B: '#forge:gears/lumium',
-                C: 'sophisticatedbackpacks:magnet_upgrade',
+                C: '#sophisticatedbackpacks:upgrades/magnet',
                 D: 'create:electron_tube'
             },
             id: 'sophisticatedbackpacks:advanced_magnet_upgrade_from_basic'
@@ -134,7 +134,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'naturesaura:hopper_upgrade',
                 B: '#forge:gears/lumium',
-                C: 'sophisticatedbackpacks:pickup_upgrade',
+                C: '#sophisticatedbackpacks:upgrades/pickup',
                 D: 'create:electron_tube'
             },
             id: 'sophisticatedbackpacks:advanced_pickup_upgrade'
@@ -143,9 +143,9 @@ onEvent('recipes', (event) => {
             output: 'sophisticatedbackpacks:advanced_void_upgrade',
             pattern: ['EAE', 'BCB', 'DDD'],
             key: {
-                A: 'create:attribute_filter',
+                A: '#sophisticatedbackpacks:upgrades/advanced_filter',
                 B: '#forge:gears/lumium',
-                C: 'sophisticatedbackpacks:void_upgrade',
+                C: '#sophisticatedbackpacks:upgrades/void',
                 D: 'create:electron_tube',
                 E: 'create:precision_mechanism'
             },
@@ -157,7 +157,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'create:fluid_pipe',
                 B: 'create:fluid_tank',
-                C: 'sophisticatedbackpacks:upgrade_base'
+                C: '#sophisticatedbackpacks:upgrades/base'
             },
             id: 'sophisticatedbackpacks:tank_upgrade'
         },
@@ -167,7 +167,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'thermal:flux_capacitor',
                 B: 'thermal:rf_coil',
-                C: 'sophisticatedbackpacks:upgrade_base'
+                C: '#sophisticatedbackpacks:upgrades/base'
             },
             id: 'sophisticatedbackpacks:battery_upgrade'
         },
@@ -178,7 +178,7 @@ onEvent('recipes', (event) => {
                 A: 'quark:bottled_cloud',
                 B: Item.of('minecraft:enchanted_book').enchant('minecraft:protection', 1),
                 C: Item.of('minecraft:enchanted_book').enchant('minecraft:blast_protection', 1),
-                D: 'sophisticatedbackpacks:upgrade_base',
+                D: '#sophisticatedbackpacks:upgrades/base',
                 E: Item.of('minecraft:enchanted_book').enchant('minecraft:fire_protection', 1),
                 F: Item.of('minecraft:enchanted_book').enchant('minecraft:projectile_protection', 1)
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/sophisticatedbackpacks/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/sophisticatedbackpacks/shaped.js
@@ -17,13 +17,13 @@ onEvent('recipes', (event) => {
 
     const recipes = [
         {
-            output: '#sophisticatedbackpacks:upgrades/base',
+            output: 'sophisticatedbackpacks:upgrade_base',
             pattern: ['AAA', 'ABA', 'AAA'],
             key: {
                 A: 'kubejs:scented_stick',
                 B: 'farmersdelight:canvas'
             },
-            id: '#sophisticatedbackpacks:upgrades/base'
+            id: 'sophisticatedbackpacks:upgrade_base'
         },
         {
             output: 'sophisticatedbackpacks:backpack',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
@@ -223,7 +223,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:ingots/andesite_alloy',
                 B: 'minecraft:hopper',
-                C: 'create:filter',
+                C: '#sophisticatedbackpacks:upgrades/filter',
                 D: 'thermal:machine_frame',
                 E: '#forge:gears/iron',
                 F: 'thermal:rf_coil'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -307,26 +307,7 @@ onEvent('recipes', (event) => {
                 consume_fluid: 0.05
             })
             .id(`enigmatica:expert/magical_ore_processing/starlight/${material}`);
-        /*
-        // Step Five: Fuse!
-        event.custom({
-            type: 'botania:runic_altar',
-            output: { item: ingot, count: 1 },
-            mana: 2500,
-            ingredients: [
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(fusing_input).toJson(),
-                Ingredient.of(`#botania:runes/nidavellir`).toJson()
-            ]
-        });
-        */
+
         // Step Five: Blood!
         event.recipes.bloodmagic
             .altar(nugget, fusing_input)


### PR DESCRIPTION
Using Create filters as crafting items is causing some conflicts with RS. Removing them.

Pulverizer
![image](https://user-images.githubusercontent.com/9543430/152075861-c4ad02d2-a524-4148-a42e-de951c1a870b.png)

Crusher
![image](https://user-images.githubusercontent.com/9543430/152075876-c33739ec-7c5d-4830-a728-53281a8dbf82.png)

XP Pump
![image](https://user-images.githubusercontent.com/9543430/152075897-6d5fbb50-8d3e-43de-89f1-168b469de993.png)

Toolswapper
![image](https://user-images.githubusercontent.com/9543430/152079349-e38bddfb-e36c-4f9c-9345-4ef04215651b.png)

Advanced Compacting
![image](https://user-images.githubusercontent.com/9543430/152079331-c3712be1-ab96-4397-ad3b-36a377cadc3e.png)

Advanced Pump
![image](https://user-images.githubusercontent.com/9543430/152076727-102f72e4-2d55-4ae7-b097-1f524d1ac443.png)

Compacting Upgrade moved to Enchanting Apparatus
![image](https://user-images.githubusercontent.com/9543430/152079313-e536e645-9712-4c0a-90b2-e59cd438b555.png)

This is because it's proving rather more complicated for crafting Compacting Drawers (which use the advanced version) via RS. Two chained rituals with RS already not handling a single ritual well. This brings it down to only 1 ritual, so all the items can be output, ritual performed, then an external crafter picks up the final craft to the drawer. 