### PR TITLE
[Expert] fix RS cables and [Base] remove extra quartz processing recipe in Create

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -95,6 +95,7 @@ onEvent('recipes', (event) => {
         'create:pressing/lapis_block',
         'create:fill_minecraft_bucket_with_create_honey',
         'create:crushing/dense_construction_block',
+        'create:crushing/nether_quartz_ore',
 
         'dustrial_decor:ice_chain',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/refinedstorage/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/refinedstorage/shaped.js
@@ -17,7 +17,18 @@ onEvent('recipes', (event) => {
 
     const recipes = [
         {
-            output: Item.of('4x refinedstorage:cable'),
+            output: Item.of('8x refinedstorage:cable'),
+            pattern: ['ADA', 'BCB', 'ADA'],
+            key: {
+                A: 'refinedstorage:quartz_enriched_iron',
+                B: 'immersiveengineering:connector_bundled',
+                C: 'immersiveengineering:wirecoil_redstone',
+                D: 'prettypipes:pipe'
+            },
+            id: 'refinedstorage:cable'
+        },
+        {
+            output: Item.of('8x refinedstorage:cable'),
             pattern: ['DBD', 'ACA', 'DBD'],
             key: {
                 A: 'refinedstorage:quartz_enriched_iron',
@@ -25,7 +36,7 @@ onEvent('recipes', (event) => {
                 C: 'immersiveengineering:wirecoil_redstone',
                 D: 'integrateddynamics:cable'
             },
-            id: 'refinedstorage:cable'
+            id: `${id_prefix}cable_alt`
         },
         {
             output: 'refinedstorage:importer',


### PR DESCRIPTION
Re-add older RS cable recipe and make the newer one a way of recycling ID cables instead
![image](https://user-images.githubusercontent.com/9543430/152199056-d5483fe8-356b-44ce-894d-caa2d47d16dc.png)

Also removes an undesired quartz recipe from Create. Resolves: #4174