### PR TITLE
Fix Stasis Chamber power use.

### DIFF
--- a/config/configswapper/expert/config/industrialforegoing/machine-misc.toml
+++ b/config/configswapper/expert/config/industrialforegoing/machine-misc.toml
@@ -17,7 +17,7 @@
 		#Cooldown Time in Ticks [20 Ticks per Second] - Default: [50 (5s)]
 		maxProgress = 50
 		#Amount of Power Consumed per Tick - Default: [400FE]
-		powerPerOperation = 3000000
+		powerPerOperation = 1500000
 		#If true, the boss bar of an entity with the AI disable won't be rendered
 		disableBossBars = true
 


### PR DESCRIPTION
Makes the Stasis Chamber use the intended 60k rf/t, as the cycle time is actually 25 ticks, not 50.

https://user-images.githubusercontent.com/2611674/152673720-ebae7bd7-e3a9-4766-863a-ccd14f32e1e2.mp4

