### PR TITLE
[Expert] Bring Dandelifeon earlier

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -164,7 +164,7 @@ onEvent('recipes', (event) => {
                 { tag: 'botania:runes/earth' },
                 { tag: 'botania:runes/air' },
                 { item: 'undergarden:masticator_scales' },
-                { item: 'botania:life_essence' }
+                { item: 'naturesaura:calling_spirit' }
             ],
             output: { item: 'botania:dandelifeon' },
             id: 'botania:petal_apothecary/dandelifeon'


### PR DESCRIPTION
Basically trading this for the Rosa Arcana, which is the intended flower for late game mana madness. This one generates quite a bit, but at a very low rate in terms of mana per tick. Seems fair to bring it forward considering the room it takes to utilize it and the increased mana use throughout mid game.

![image](https://user-images.githubusercontent.com/9543430/153463632-9f43da08-5e93-4ee0-8082-1b85cfa3ceba.png)
