### PR TITLE
[Expert] Nebu and corundum tweaks

### DIFF
--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -864,6 +864,8 @@
 			description: [
 				"Once you've determined an appropriate spot to excavate, you can build this machine there. Be warned that the Excavator requires a rather hefty amount of energy to run."
 				""
+				"Several additional mineral nodes have been added, such as Horodric Digsites and Naqada deposits. Be sure to check in the Engineer’s Manual under “Overview and Resources” for a full list of Mineral Deposits. "
+				""
 				"Note: Building Gadgets Patterns and Create Schematics are available in your Enigmatica 6 instance folder to assist with this multiblock. "
 			]
 			dependencies: ["0000000000000061"]

--- a/config/ftbquests/quests/chapters/tech_t2.snbt
+++ b/config/ftbquests/quests/chapters/tech_t2.snbt
@@ -398,6 +398,7 @@
 		{
 			x: 3.0d
 			y: 6.0d
+			description: ["Amadron at last. But is there anyone out there still listening? Check what’s available for trade. Perhaps you’ll be surprised. "]
 			dependencies: ["5258B21FEBF3E222"]
 			id: "26BE40771EA0B53D"
 			tasks: [{

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -124,6 +124,7 @@ onEvent('recipes', (event) => {
 
         'quark:building/crafting/candles/candle_basic',
         'quark:building/crafting/red_nether_bricks_util',
+        'quark:tools/crafting/runes/rainbow_rune',
 
         'refinedstorage:quartz_enriched_iron',
         'rftoolscontrol:cpu_core_500',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -676,6 +676,22 @@ onEvent('recipes', (event) => {
             output: 'quark:black_rune',
             count: 2,
             id: `quark:tools/crafting/runes/black_rune_from_crystal`
+        },
+        {
+            inputs: [
+                'quark:red_rune',
+                'quark:orange_rune',
+                'quark:yellow_rune',
+                'quark:lime_rune',
+                'quark:light_blue_rune',
+                'quark:blue_rune',
+                'quark:magenta_rune',
+                'quark:white_rune'
+            ],
+            mana: 4000 * 8,
+            output: 'quark:rainbow_rune',
+            count: 8,
+            id: 'quark:tools/crafting/runes/rainbow_rune2'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
@@ -77,6 +77,27 @@ onEvent('recipes', (event) => {
                 rolls: 3
             },
             id: 'enigmatica:expert/interactio/item_explode/invar_dust'
+        },
+        {
+            inputs: [
+                { tag: 'botania:runes/earth', count: 1 },
+                { item: 'quark:rainbow_rune', count: 8 }
+            ],
+            output: {
+                entries: [
+                    { result: { item: 'quark:red_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:orange_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:yellow_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:green_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:blue_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:indigo_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:violet_crystal_cluster', count: 1 }, weight: 2 },
+                    { result: { item: 'quark:white_crystal_cluster', count: 1 }, weight: 2 }
+                ],
+                empty_weight: 84,
+                rolls: 100
+            },
+            id: 'enigmatica:expert/interactio/item_explode/invar_dust'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -769,12 +769,16 @@ onEvent('recipes', (event) => {
             ingredients: [
                 '#atum:godshards',
                 'atum:golden_date_enchanted',
-                '#forge:storage_blocks/nebu',
+                '#forge:ingots/nebu',
                 '#forge:heads',
                 '#atum:godshards',
                 '#atum:godshards',
-                'atum:crystal_glass',
-                'atum:crystal_glass'
+                '#forge:ingots/nebu',
+                '#forge:ingots/nebu',
+                'atum:linen_bandage',
+                'atum:linen_bandage',
+                'atum:linen_bandage',
+                'atum:linen_bandage'
             ],
             result: 'occultism:jei_dummy/none',
             id: `${id_prefix}pharaoh`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/thermo_plant.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/thermo_plant.js
@@ -155,6 +155,21 @@ onEvent('recipes', (event) => {
         }
     ];
 
+    let crystal_colors = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet', 'white', 'black'];
+
+    crystal_colors.forEach((crystal_color) => {
+        recipes.push({
+            fluid_input: { type: 'pneumaticcraft:fluid', fluid: 'tconstruct:molten_aluminum', amount: 18 },
+            item_input: { item: `quark:${crystal_color}_crystal_cluster` },
+            item_output: { item: `quark:${crystal_color}_crystal_pane`, count: 1 },
+            pressure: 4.8,
+            exothermic: false,
+            speed: 0.25,
+            temperature: { min_temp: 2200 },
+            id: `${id_prefix}${crystal_color}_crystal_pane`
+        });
+    });
+
     recipes.forEach((recipe) => {
         recipe.type = 'pneumaticcraft:thermo_plant';
         event.custom(recipe).id(recipe.id);


### PR DESCRIPTION
Lowered Nebu cost for summoning Pharaohs. #4221
![image](https://user-images.githubusercontent.com/9543430/153781246-32800a9c-717e-4980-9c4c-cac33dfbb2cf.png)

Added Rainbow Rune recycling for #4222

Blow em up with a catalyst:
![image](https://user-images.githubusercontent.com/9543430/153781286-03b0e469-1983-4e40-90a9-131d72502c4f.png)

TPP to smooth the clusters out into panes
![image](https://user-images.githubusercontent.com/9543430/153781299-00aa1c56-a832-49d1-b1a2-980aa1b12219.png)

Panes may be crafted into blocks. 
![image](https://user-images.githubusercontent.com/9543430/153781317-ffdbc2a8-095e-4cb2-acaf-c63677f6b0cd.png)

This provides an alternate path to obtaining most of the corundum colors. 

Also moves the rainbow rune craft onto the runic altar with the rest: 
![image](https://user-images.githubusercontent.com/9543430/153781411-2a491c44-0b86-4a92-8442-60e7ef51d963.png)
