### PR TITLE
Fix Wasabee Crash

### DIFF
--- a/config/resourcefulbees/bees/dev/Kitten.json
+++ b/config/resourcefulbees/bees/dev/Kitten.json
@@ -40,5 +40,12 @@
     },
     "TraitData": {
       "hasTraits": true
+    },
+    "BreedData": {
+        "isBreedable": false,
+        "feedItem": "tag:minecraft:fishes",
+        "feedAmount": 1,
+        "childGrowthDelay": -24000,
+        "breedDelay": 6000
     }
   }


### PR DESCRIPTION
Adds a breeding item - fish - which solves a beepedia crash. Fixes #4076.