### PR TITLE
[Expert] Add recipes for items used in Tree of Life which are otherwise unobtainable.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -101,6 +101,24 @@ onEvent('recipes', (event) => {
             aura: 100,
             time: 20,
             id: 'integrateddynamics:crafting/part_display_panel'
+        },
+        {
+            input: 'botania:redstone_root',
+            output: { item: 'botania:root' },
+            catalyst: { item: 'naturesaura:conversion_catalyst' },
+            aura_type: 'naturesaura:overworld',
+            aura: 1500,
+            time: 20,
+            id: `${id_prefix}root`
+        },
+        {
+            input: 'minecraft:lily_pad',
+            output: { item: 'environmental:duckweed' },
+            catalyst: { item: 'naturesaura:conversion_catalyst' },
+            aura_type: 'naturesaura:overworld',
+            aura: 15000,
+            time: 80,
+            id: `${id_prefix}duckweed`
         }
     ];
 


### PR DESCRIPTION
Duckweed, used for duckweed thatch. Might be found in world. Dunno. Better to err on the side of caution.
![image](https://user-images.githubusercontent.com/9543430/155073417-e7d86e1d-386f-4528-ac93-acfa0e4de4b7.png)

Living Root:
![image](https://user-images.githubusercontent.com/9543430/155073499-c1fdd1e0-31d9-4c23-8aba-b43cfa3a573c.png)
