### PR TITLE
Remove Mimicream from Hemolymph Blaster recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/alexsmobs/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/alexsmobs/shaped.js
@@ -1,0 +1,19 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        {
+            output: 'alexsmobs:hemolymph_blaster',
+            pattern: ['AAA', 'BCD'],
+            key: {
+                A: 'alexsmobs:hemolymph_sac',
+                B: 'alexsmobs:warped_muscle',
+                C: 'alexsmobs:blood_sprayer',
+                D: 'alexsmobs:mosquito_proboscis'
+            },
+            id: 'alexsmobs:hemolymph_blaster'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});


### PR DESCRIPTION
Was un-craftable due to the disabling of mimicream in the pack