### PR TITLE
Fix crafting recipes for signs and chests

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -74,6 +74,8 @@ onEvent('recipes', (event) => {
         'astralsorcery:infuser/gold_ore',
         'astralsorcery:shaped/marble/marble_slab',
 
+        /atmospheric:\w+_chest_wood/,
+
         'atum:pumpkin_pie',
 
         'betterendforge:gunpowder_from_sulphur',
@@ -107,6 +109,7 @@ onEvent('recipes', (event) => {
 
         'environmental:misc/cherries/cherry_pie',
         'environmental:misc/apple_pie',
+        /environmental:building\/wood\/\w+\/\w+_chest_wood/,
 
         'farmersdelight:cutting/chicken',
         'farmersdelight:integration/create/mixing/pie_crust_from_mixing',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/atmospheric/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/atmospheric/shaped.js
@@ -1,0 +1,34 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/atmospheric/shaped/';
+    const recipes = [
+        {
+            output: Item.of('3x atmospheric:aspen_sign'),
+            pattern: ['AAA', 'AAA', ' B '],
+            key: {
+                A: ['byg:aspen_planks', 'atmospheric:aspen_planks', 'projectvibrantjourneys:aspen_planks'],
+                B: '#forge:rods/wooden'
+            },
+            id: 'atmospheric:aspen_sign'
+        },
+        {
+            output: 'atmospheric:aspen_chest',
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:aspen_planks', 'atmospheric:aspen_planks', 'projectvibrantjourneys:aspen_planks']
+            },
+            id: 'atmospheric:aspen_chest'
+        },
+        {
+            output: Item.of('4x atmospheric:aspen_chest'),
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:aspen_log', 'atmospheric:aspen_log', 'projectvibrantjourneys:aspen_log']
+            },
+            id: `${id_prefix}aspen_chest_from_logs`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shaped.js
@@ -1,8 +1,7 @@
 onEvent('recipes', (event) => {
-    const id_prefix = 'enigmatica:base/enigmatica/';
+    const id_prefix = 'enigmatica:base/enigmatica/shaped/';
     const recipes = [
         {
-            // Add Blaze + Coal Comb -> Lava Bucket Recipe
             output: 'minecraft:lava_bucket',
             pattern: ['BDB', 'CAC', 'BDB'],
             key: {
@@ -387,22 +386,21 @@ onEvent('recipes', (event) => {
         if (wood.modId == 'minecraft') {
             return;
         }
-        let craftingTable = wood.modId + ':' + wood.logType + '_crafting_table';
-        if (!Item.exists(craftingTable)) {
-            event.shaped('minecraft:crafting_table', ['AA', 'AA'], {
-                A: wood.plankBlock
-            });
-        }
+
         //All recipes using logs here
         var chest = wood.modId + ':' + wood.logType + '_chest';
         if (!Item.exists(chest)) {
-            event.shaped(Item.of('minecraft:chest', 4), ['AAA', 'A A', 'AAA'], {
-                A: wood.logBlock
-            });
+            event
+                .shaped(Item.of('minecraft:chest', 4), ['AAA', 'A A', 'AAA'], {
+                    A: wood.logBlock
+                })
+                .id(`${id_prefix}chest_from_${wood.logBlock.replace(':', '_')}`);
         } else {
-            event.shaped(Item.of(chest, 4), ['AAA', 'A A', 'AAA'], {
-                A: wood.logBlock
-            });
+            event
+                .shaped(Item.of(chest, 4), ['AAA', 'A A', 'AAA'], {
+                    A: wood.logBlock
+                })
+                .id(`${id_prefix}${chest.replace(':', '_')}_from_${wood.logBlock.replace(':', '_')}`);
         }
 
         var dupes = [
@@ -423,14 +421,32 @@ onEvent('recipes', (event) => {
         }
 
         //All recipes using planks here
-        event.shaped(Item.of('minecraft:oak_sign', 3), ['AAA', 'AAA', ' B '], {
-            A: wood.plankBlock,
-            B: '#forge:rods/wooden'
-        });
 
-        event.shaped(Item.of('minecraft:chest'), ['AAA', 'A A', 'AAA'], {
-            A: wood.plankBlock
-        });
+        let craftingTable = wood.modId + ':' + wood.logType + '_crafting_table';
+        if (!Item.exists(craftingTable)) {
+            event
+                .shaped('minecraft:crafting_table', ['AA', 'AA'], {
+                    A: wood.plankBlock
+                })
+                .id(`${id_prefix}crafting_table_from_${wood.plankBlock.replace(':', '_')}`);
+        }
+
+        if (!sign_wood_type_blacklist.includes(wood.logType)) {
+            event
+                .shaped(Item.of('minecraft:oak_sign'), ['AAA', 'AAA', ' B '], {
+                    A: wood.plankBlock,
+                    B: '#forge:rods/wooden'
+                })
+                .id(`${id_prefix}oak_sign_from_${wood.plankBlock.replace(':', '_')}`);
+        }
+
+        if (!chest_wood_type_blacklist.includes(wood.logType)) {
+            event
+                .shaped(Item.of('minecraft:chest'), ['AAA', 'A A', 'AAA'], {
+                    A: wood.plankBlock
+                })
+                .id(`${id_prefix}chest_from_${wood.plankBlock.replace(':', '_')}`);
+        }
     });
 
     //Generate Forest Comb recipes for each tree type other than Oak (those are handled under newRecipes)
@@ -438,25 +454,31 @@ onEvent('recipes', (event) => {
         if (treeCategories.type == 'tree') {
             treeCategories.trees.forEach((tree) => {
                 if (tree.trunk != 'minecraft:oak_log') {
-                    event.shaped(Item.of(tree.trunk, 8), ['BCB', 'CAC', 'BCB'], {
-                        A: tree.sapling,
-                        C: 'resourcefulbees:forest_honeycomb',
-                        B: 'resourcefulbees:wax'
-                    });
+                    event
+                        .shaped(Item.of(tree.trunk, 8), ['BCB', 'CAC', 'BCB'], {
+                            A: tree.sapling,
+                            C: 'resourcefulbees:forest_honeycomb',
+                            B: 'resourcefulbees:wax'
+                        })
+                        .id(`${id_prefix}${tree.trunk.replace(':', '_')}_from_${tree.sapling.replace(':', '_')}`);
                 }
                 if (tree.sapling != 'minecraft:oak_sapling') {
-                    event.shaped(Item.of(tree.sapling, 4), [' C ', 'BAB', ' C '], {
-                        A: tree.sapling,
-                        C: 'resourcefulbees:forest_honeycomb',
-                        B: 'resourcefulbees:wax'
-                    });
+                    event
+                        .shaped(Item.of(tree.sapling, 4), [' C ', 'BAB', ' C '], {
+                            A: tree.sapling,
+                            C: 'resourcefulbees:forest_honeycomb',
+                            B: 'resourcefulbees:wax'
+                        })
+                        .id(`${id_prefix}${tree.sapling.replace(':', '_')}_from_${tree.sapling.replace(':', '_')}`);
                 }
                 if (tree.leaf != 'minecraft:oak_leaves') {
-                    event.shaped(Item.of(tree.leaf, 16), ['   ', 'BAC', '   '], {
-                        A: tree.sapling,
-                        C: 'resourcefulbees:forest_honeycomb',
-                        B: 'resourcefulbees:wax'
-                    });
+                    event
+                        .shaped(Item.of(tree.leaf, 16), ['   ', 'BAC', '   '], {
+                            A: tree.sapling,
+                            C: 'resourcefulbees:forest_honeycomb',
+                            B: 'resourcefulbees:wax'
+                        })
+                        .id(`${id_prefix}${tree.leaf.replace(':', '_')}_from_${tree.sapling.replace(':', '_')}`);
                 }
             });
         }
@@ -466,10 +488,12 @@ onEvent('recipes', (event) => {
     colors.forEach((color) => {
         let flowers = dyeSources.filter((dyeSource) => dyeSource.primary == `minecraft:${color}_dye`);
         let ingredients = flowers.map((flower) => flower.input);
-        event.shaped(Item.of(`minecraft:${color}_dye`, 8), ['BCB', 'CAC', 'BCB'], {
-            A: ingredients,
-            C: 'resourcefulbees:rgbee_honeycomb',
-            B: 'resourcefulbees:wax'
-        });
+        event
+            .shaped(Item.of(`minecraft:${color}_dye`, 8), ['BCB', 'CAC', 'BCB'], {
+                A: ingredients,
+                C: 'resourcefulbees:rgbee_honeycomb',
+                B: 'resourcefulbees:wax'
+            })
+            .id(`${id_prefix}${color}_dye_from_rgbee_honeycomb`);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/environmental/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/environmental/shaped.js
@@ -1,5 +1,5 @@
 onEvent('recipes', (event) => {
-    const id_prefix = 'enigmatica:base/environmental/shaped';
+    const id_prefix = 'enigmatica:base/environmental/shaped/';
     /*
         ,
         {
@@ -30,6 +30,58 @@ onEvent('recipes', (event) => {
                 B: '#forge:ices/packed'
             },
             id: 'environmental:building/ice_chain'
+        },
+        {
+            output: Item.of('3x environmental:willow_sign'),
+            pattern: ['AAA', 'AAA', ' B '],
+            key: {
+                A: ['byg:willow_planks', 'environmental:willow_planks', 'projectvibrantjourneys:willow_planks'],
+                B: '#forge:rods/wooden'
+            },
+            id: 'environmental:building/wood/willow/willow_sign'
+        },
+        {
+            output: Item.of('3x environmental:cherry_sign'),
+            pattern: ['AAA', 'AAA', ' B '],
+            key: {
+                A: ['byg:cherry_planks', 'atmospheric:cherry_planks', 'projectvibrantjourneys:sakura_planks'],
+                B: '#forge:rods/wooden'
+            },
+            id: 'environmental:building/wood/cherry/cherry_sign'
+        },
+
+        {
+            output: 'environmental:willow_chest',
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:willow_planks', 'environmental:willow_planks', 'projectvibrantjourneys:willow_planks']
+            },
+            id: 'environmental:building/wood/willow/willow_chest'
+        },
+        {
+            output: 'environmental:cherry_chest',
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:cherry_planks', 'atmospheric:cherry_planks', 'projectvibrantjourneys:sakura_planks']
+            },
+            id: 'environmental:building/wood/cherry/cherry_chest'
+        },
+
+        {
+            output: Item.of('4x environmental:willow_chest'),
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:willow_log', 'environmental:willow_log', 'projectvibrantjourneys:willow_log']
+            },
+            id: `${id_prefix}willow_chest_from_logs`
+        },
+        {
+            output: Item.of('4x environmental:cherry_chest'),
+            pattern: ['AAA', 'A A', 'AAA'],
+            key: {
+                A: ['byg:cherry_log', 'atmospheric:cherry_log', 'projectvibrantjourneys:sakura_log']
+            },
+            id: `${id_prefix}cherry_chest_from_logs`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/general.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/general.js
@@ -71,5 +71,61 @@ const createStoneTypes = [
     'natural_scoria'
 ];
 
+const sign_wood_type_blacklist = [
+    'aspen',
+    'bloodshroom',
+    'cherry',
+    'deadwood',
+    'dragon_tree',
+    'driftwood',
+    'end_lotus',
+    'greenheart',
+    'grimwood',
+    'grongle',
+    'helix_tree',
+    'jellyshroom',
+    'kousa',
+    'lacugrove',
+    'lucernia',
+    'morado',
+    'mossy_glowshroom',
+    'palm',
+    'pythadendron',
+    'river',
+    'rosewood',
+    'sakura',
+    'skyroot',
+    'smogstem',
+    'tenanea',
+    'umbrella_tree',
+    'wigglewood',
+    'willow',
+    'wisteria',
+    'yucca'
+];
+
+const chest_wood_type_blacklist = [
+    'aspen',
+    'cherry',
+    'dragon_tree',
+    'driftwood',
+    'grimwood',
+    'helix_tree',
+    'jellyshroom',
+    'kousa',
+    'lacugrove',
+    'lucernia',
+    'morado',
+    'mossy_glowshroom',
+    'pythadendron',
+    'river',
+    'rosewood',
+    'tenanea',
+    'umbrella_tree',
+    'willow',
+    'wisteria',
+    'yucca'
+];
+
 const normalMode = global.packmode == 'normal';
 const expertMode = global.packmode == 'expert';


### PR DESCRIPTION
Resolves #4288

wood types that have their own chest and sign types no longer make minecraft oak chests or signs.