### PR TITLE
[Expert] polished wood and eidolon progression fixes

### DIFF
--- a/kubejs/client_scripts/expert/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/expert/item_modifiers/tooltips.js
@@ -43,6 +43,7 @@ onEvent('item.tooltip', (event) => {
                 'pneumaticcraft:advanced_air_compressor',
                 'darkutils:rune_damage_player',
                 'eidolon:crucible',
+                'eidolon:wooden_brewing_stand',
                 'tanknull:dock',
                 'dankstorage:dock'
             ],

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/ladder_planks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/ladder_planks.js
@@ -17,6 +17,7 @@ onEvent('item.tags', (event) => {
             'betterendforge:end_lotus_planks',
             'betterendforge:lacugrove_planks',
             'betterendforge:mossy_glowshroom_planks',
+            'eidolon:polished_planks',
             'environmental:wisteria_planks',
             'environmental:cherry_planks',
             'environmental:willow_planks',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/planks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/planks.js
@@ -11,4 +11,6 @@ onEvent('item.tags', (event) => {
     event.get('forge:planks/smogstem').add('undergarden:smogstem_planks');
     event.get('forge:planks/grongle').add('undergarden:grongle_planks');
     event.get('forge:planks/wigglewood').add('undergarden:wigglewood_planks');
+
+    event.get('forge:planks').remove('eidolon:polished_planks');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/minecraft/planks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/minecraft/planks.js
@@ -1,0 +1,3 @@
+onEvent('item.tags', (event) => {
+    event.get('minecraft:planks').remove('eidolon:polished_planks');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -19,6 +19,7 @@ onEvent('recipes', (event) => {
 
         'atum:blast_furnace',
         'atum:book',
+        'atum:ore_brewing_stand',
 
         'betterendforge:leather_to_stripes',
 
@@ -47,6 +48,7 @@ onEvent('recipes', (event) => {
         /darkutils:crafting\/export_plate/,
 
         'eidolon:crucible',
+        'eidolon:wooden_brewing_stand',
 
         'farmersdelight:book_from_canvas',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -194,7 +194,7 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 '#forge:nuggets/gold_brass',
-                'eidolon:wooden_brewing_stand',
+                'minecraft:brewing_stand',
                 '#forge:nuggets/gold_brass',
                 '#forge:ingots/gold_brass',
                 '#forge:ingots/gold_brass',
@@ -2077,7 +2077,7 @@ onEvent('recipes', (event) => {
                 'ars_nouveau:glyph_craft',
                 '#forge:nuggets/arcane_gold',
                 'architects_palette:twisted_sapling',
-                'eidolon:wooden_brewing_stand',
+                'minecraft:brewing_stand',
                 '#forge:nuggets/arcane_gold',
                 '#forge:coins/electrum',
                 '#forge:nuggets/arcane_gold'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/eidolon/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/eidolon/shaped.js
@@ -56,6 +56,16 @@ onEvent('recipes', (event) => {
                 D: 'minecraft:nether_brick_fence'
             },
             id: 'eidolon:brazier'
+        },
+        {
+            output: 'eidolon:wooden_altar',
+            pattern: ['AAA', 'CBC', 'D CBC'],
+            key: {
+                A: 'quark:brown_stained_planks_slab',
+                B: 'kubejs:scented_stick',
+                C: 'quark:brown_stained_planks_vertical_slab'
+            },
+            id: 'eidolon:wooden_altar'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/minecraft/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/minecraft/shaped.js
@@ -112,6 +112,16 @@ onEvent('recipes', (event) => {
                 E: 'quark:diamond_heart'
             },
             id: 'minecraft:enchanting_table'
+        },
+        {
+            output: 'minecraft:brewing_stand',
+            pattern: ['ABA', ' B ', 'CCC'],
+            key: {
+                A: '#forge:nuggets/invar',
+                B: '#forge:rods/brass',
+                C: '#forge:ingots/pewter'
+            },
+            id: 'minecraft:brewing_stand'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
@@ -363,7 +363,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'thermal:rf_coil',
                 B: 'ars_nouveau:warding_stone',
-                C: 'eidolon:wooden_brewing_stand',
+                C: 'minecraft:brewing_stand',
                 D: 'atum:coin_gold',
                 E: 'farmersdelight:cooking_pot'
             },


### PR DESCRIPTION
Removes polished wood from planks tags, preventing accidental usage in recipes. Resolves: #4306

Removes the Eidolon Apothecary Stand as it's useless without the cauldron.

Change recipe for vanilla brewing as a result. Also updated any recipes previously using the Apothecary Stand to use the Brewing stand now.
![image](https://user-images.githubusercontent.com/9543430/156091147-7ffeab1f-0716-46cb-91cb-f252f5edc297.png)

Fix Wooden Altar to no longer require polished wood.
![image](https://user-images.githubusercontent.com/9543430/156091539-88e7fff6-3986-45e4-8540-b819b4dba972.png)

