### PR TITLE
Add Overworld worldgen bees to Beekeeper villager

### DIFF
--- a/config/enigmatica/beekeeper.json
+++ b/config/enigmatica/beekeeper.json
@@ -1,0 +1,547 @@
+{
+    "profession": "resourcefulbees:beekeeper",
+    "replace": "false",
+    "trades": 
+    [
+        {
+            "level": 1,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "minecraft:bee"},
+                "emerald_count": 6,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:zombie_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:water_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:slimy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:skeleton_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:sand_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:rocky_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:icy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:coal_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:creeper_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:forest_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:obsidian_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 2,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:zombie_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:water_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:slimy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:skeleton_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:sand_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:rocky_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:icy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:coal_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:creeper_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:forest_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 3,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:obsidian_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:zombie_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:water_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:slimy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:skeleton_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:sand_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:rocky_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:icy_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:coal_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:creeper_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:forest_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 4,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:obsidian_bee"},
+                "emerald_count": 64,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 24
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:zombie_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:water_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:slimy_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:skeleton_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:sand_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:rocky_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:icy_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:coal_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:creeper_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:forest_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        },
+        {
+            "level": 5,
+            "trade": {
+                "type": "minecraft:items_for_emeralds",
+                "item": "resourcefulbees:bee_jar",
+                "nbt": {"Entity": "resourcefulbees:obsidian_bee"},
+                "emerald_count": 32,
+                "count": 1,
+                "max_uses": 1,
+                "xp_value": 12
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Basically adds everything from Moto's PR to the beekeeper villager except the non-overworld bees as they would actually be progression breaking here. All added bees are available at trade levels 2-5, and added vanilla bees to lvl 1 trades.

https://gyazo.com/3eb4b2a963969b6bd87db4275f2914ea