### PR TITLE
disable random jukebox upgrade at mobs

### DIFF
--- a/config/sophisticatedbackpacks-common.toml
+++ b/config/sophisticatedbackpacks-common.toml
@@ -376,7 +376,7 @@
 		#List of music discs that are not supposed to be played by entities
 		discBlockList = ["botania:record_gaia_1", "botania:record_gaia_2"]
 		#Turns on/off a chance that the entity that wears backpack gets jukebox upgrade and plays a music disc.
-		playJukebox = true
+		playJukebox = false
 		#Chance of mob dropping backpack when killed by player
 		#Range: 0.0 ~ 1.0
 		backpackDropChance = 0.085


### PR DESCRIPTION
mobs wearing a backpack have a certain chance of getting a jukebox upgrade
this change prevents that