### PR TITLE
Add packmenu config to config swapper for menu logo

### DIFF
--- a/config/configswapper/expert/config/packmenu.cfg
+++ b/config/configswapper/expert/config/packmenu.cfg
@@ -1,0 +1,132 @@
+# Configuration file
+
+"forge info" {
+    # The anchor point for this element. [default: FORGE]
+    S:"Anchor Point"=FORGE
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+general {
+    # If forge information is drawn at the top center.  This includes beta and update warnings. [default: true]
+    B:"Draw Forge Info"=false
+
+    # If the "Java Edition" text is drawn. [default: true]
+    B:"Draw Java Edition"=false
+
+    # If the vanilla panorama, and it's fade-in, are rendered.  Enabling this disables the use of the custom background options. [default: false]
+    B:"Draw Panorama"=true
+
+    # If the splash text is drawn. [default: true]
+    B:"Draw Splash"=false
+
+    # If the title (the giant minecraft text) is drawn. [default: true]
+    B:"Draw Title"=false
+
+    # If the resource pack is loaded from /resources instead of /resources.zip [default: true]
+    B:"Folder Pack"=true
+
+    # If the Panorama has a fade-in effect. [default: false]
+    B:"Panorama Fade In"=false
+
+    # A multiplier on panorama speed. [range: 0.01 ~ 100.0, default: 1.0]
+    S:"Panorama Speed"=0.5
+
+    # The number of variations of panorama that exist.  Panorama files other than the original set must have the form panorama<y>_<z>.png.  For example the first file of varation #2 would be panorama1_0.png [range: 1 ~ 10, default: 1]
+    I:"Panorama Variations"=1
+}
+
+
+"java edition text" {
+    # The anchor point for this element. [default: JAVAED]
+    S:"Anchor Point"=JAVAED
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+logo {
+    # The anchor point of the logo.  The types of anchor points are available on the wiki. [default: DEFAULT_LOGO]
+    S:"Anchor Point"=TOP_CENTER
+
+    # The height of the logo. [range: 0 ~ 500000, default: 100]
+    I:Height=145
+
+    # The height of the logo's texture. [range: 0 ~ 500000, default: 300]
+    I:"Texture Height"=145
+
+    # The location of the logo texture.  Must be a png file.  Should contain the extension. [default: packmenu:textures/gui/logo.png]
+    S:"Texture Path"=enigmatica:textures/logo_expert.png
+
+    # The width of the logo's texture. [range: 0 ~ 500000, default: 300]
+    I:"Texture Width"=350
+
+    # The width of the logo. [range: 0 ~ 500000, default: 100]
+    I:Width=350
+
+    # The X offset of the logo. [range: -500000 ~ 500000, default: -650]
+    I:"X Offset"=-175
+
+    # The Y offset of the logo. [range: -500000 ~ 500000, default: 0]
+    I:"Y Offset"=5
+}
+
+
+slideshow {
+    # How long between slideshow transitions. [range: 1 ~ 1000000, default: 200]
+    I:Duration=200
+
+    # The list of textures to be displayed on the slideshow.  If empty, the slideshow is ignored. [default: ]
+    S:Textures <
+     >
+
+    # How long the slideshow transition lasts. [range: 1 ~ 1000000, default: 20]
+    I:"Transition Duration"=20
+}
+
+
+"splash text" {
+    # The anchor point for this element. [default: SPLASH]
+    S:"Anchor Point"=SPLASH
+
+    # The color of the splash text. [range: -2147483647 ~ 2147483647, default: -256]
+    I:Color=-256
+
+    # The rotation value of the splash text. [range: -360.0 ~ 360.0, default: -20.0]
+    S:Rotation=-20.0
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+support {
+    # The URL that the link on the supporters page goes to. [default: https://www.patreon.com/Shadows_of_Fire?fan_landing=true]
+    S:"Patreon Url"=https://www.patreon.com/Shadows_of_Fire?fan_landing=true
+}
+
+
+title {
+    # The anchor point for this element. [default: TITLE]
+    S:"Anchor Point"=TITLE
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+

--- a/config/configswapper/normal/config/packmenu.cfg
+++ b/config/configswapper/normal/config/packmenu.cfg
@@ -1,0 +1,132 @@
+# Configuration file
+
+"forge info" {
+    # The anchor point for this element. [default: FORGE]
+    S:"Anchor Point"=FORGE
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+general {
+    # If forge information is drawn at the top center.  This includes beta and update warnings. [default: true]
+    B:"Draw Forge Info"=false
+
+    # If the "Java Edition" text is drawn. [default: true]
+    B:"Draw Java Edition"=false
+
+    # If the vanilla panorama, and it's fade-in, are rendered.  Enabling this disables the use of the custom background options. [default: false]
+    B:"Draw Panorama"=true
+
+    # If the splash text is drawn. [default: true]
+    B:"Draw Splash"=false
+
+    # If the title (the giant minecraft text) is drawn. [default: true]
+    B:"Draw Title"=false
+
+    # If the resource pack is loaded from /resources instead of /resources.zip [default: true]
+    B:"Folder Pack"=true
+
+    # If the Panorama has a fade-in effect. [default: false]
+    B:"Panorama Fade In"=false
+
+    # A multiplier on panorama speed. [range: 0.01 ~ 100.0, default: 1.0]
+    S:"Panorama Speed"=0.5
+
+    # The number of variations of panorama that exist.  Panorama files other than the original set must have the form panorama<y>_<z>.png.  For example the first file of varation #2 would be panorama1_0.png [range: 1 ~ 10, default: 1]
+    I:"Panorama Variations"=1
+}
+
+
+"java edition text" {
+    # The anchor point for this element. [default: JAVAED]
+    S:"Anchor Point"=JAVAED
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+logo {
+    # The anchor point of the logo.  The types of anchor points are available on the wiki. [default: DEFAULT_LOGO]
+    S:"Anchor Point"=TOP_CENTER
+
+    # The height of the logo. [range: 0 ~ 500000, default: 100]
+    I:Height=98
+
+    # The height of the logo's texture. [range: 0 ~ 500000, default: 300]
+    I:"Texture Height"=98
+
+    # The location of the logo texture.  Must be a png file.  Should contain the extension. [default: packmenu:textures/gui/logo.png]
+    S:"Texture Path"=enigmatica:textures/logo_normal.png
+
+    # The width of the logo's texture. [range: 0 ~ 500000, default: 300]
+    I:"Texture Width"=350
+
+    # The width of the logo. [range: 0 ~ 500000, default: 100]
+    I:Width=350
+
+    # The X offset of the logo. [range: -500000 ~ 500000, default: -650]
+    I:"X Offset"=-175
+
+    # The Y offset of the logo. [range: -500000 ~ 500000, default: 0]
+    I:"Y Offset"=5
+}
+
+
+slideshow {
+    # How long between slideshow transitions. [range: 1 ~ 1000000, default: 200]
+    I:Duration=200
+
+    # The list of textures to be displayed on the slideshow.  If empty, the slideshow is ignored. [default: ]
+    S:Textures <
+     >
+
+    # How long the slideshow transition lasts. [range: 1 ~ 1000000, default: 20]
+    I:"Transition Duration"=20
+}
+
+
+"splash text" {
+    # The anchor point for this element. [default: SPLASH]
+    S:"Anchor Point"=SPLASH
+
+    # The color of the splash text. [range: -2147483647 ~ 2147483647, default: -256]
+    I:Color=-256
+
+    # The rotation value of the splash text. [range: -360.0 ~ 360.0, default: -20.0]
+    S:Rotation=-20.0
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+
+support {
+    # The URL that the link on the supporters page goes to. [default: https://www.patreon.com/Shadows_of_Fire?fan_landing=true]
+    S:"Patreon Url"=https://www.patreon.com/Shadows_of_Fire?fan_landing=true
+}
+
+
+title {
+    # The anchor point for this element. [default: TITLE]
+    S:"Anchor Point"=TITLE
+
+    # The X offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"X Offset"=0
+
+    # The Y Offset for this element. [range: -1000 ~ 1000, default: 0]
+    I:"Y Offset"=0
+}
+
+

--- a/kubejs/startup_scripts/packmenu_reload.js
+++ b/kubejs/startup_scripts/packmenu_reload.js
@@ -1,0 +1,5 @@
+onEvent('postinit', event => {
+  // Loads Java class field
+  var client = java('shadows.menu.PackMenuClient')
+  client.loadConfig()
+})


### PR DESCRIPTION
Config swapper will need updated for this to swap the .cfg file. Thanks to Darkere for both updating configswapper and making the kubejs startup script to have the packmenu config get reloaded after swap.

Tested changing to expert and back to normal mode, works perfectly