### PR TITLE
Update Terraforged Preset to include all the new structures

### DIFF
--- a/config/terraforged/presets/Enigmatica.json
+++ b/config/terraforged/presets/Enigmatica.json
@@ -73,6 +73,228 @@
         "salt": 10387313,
         "disabled": false
       },
+      "dungeons_arise:abandoned_temple": {
+        "spacing": 30,
+        "separation": 20,
+        "salt": 43726252,
+        "disabled": false
+      },
+      "dungeons_arise:aviary": {
+        "spacing": 140,
+        "separation": 110,
+        "salt": 492512640,
+        "disabled": false
+      },
+      "dungeons_arise:bandit_towers": {
+        "spacing": 45,
+        "separation": 35,
+        "salt": 1577726208,
+        "disabled": false
+      },
+      "dungeons_arise:bandit_village": {
+        "spacing": 45,
+        "separation": 35,
+        "salt": 1111272576,
+        "disabled": false
+      },
+      "dungeons_arise:ceryneian_hind": {
+        "spacing": 80,
+        "separation": 70,
+        "salt": 222266352,
+        "disabled": false
+      },
+      "dungeons_arise:coliseum": {
+        "spacing": 240,
+        "separation": 200,
+        "salt": 1626626688,
+        "disabled": false
+      },
+      "dungeons_arise:fishing_hut": {
+        "spacing": 20,
+        "separation": 5,
+        "salt": 643827200,
+        "disabled": false
+      },
+      "dungeons_arise:foundry": {
+        "spacing": 120,
+        "separation": 60,
+        "salt": 277663648,
+        "disabled": false
+      },
+      "dungeons_arise:giant_mushroom": {
+        "spacing": 80,
+        "separation": 40,
+        "salt": 497362528,
+        "disabled": false
+      },
+      "dungeons_arise:heavenly_challenger": {
+        "spacing": 340,
+        "separation": 290,
+        "salt": 826638848,
+        "disabled": false
+      },
+      "dungeons_arise:heavenly_conqueror": {
+        "spacing": 230,
+        "separation": 190,
+        "salt": 374552448,
+        "disabled": false
+      },
+      "dungeons_arise:heavenly_rider": {
+        "spacing": 180,
+        "separation": 160,
+        "salt": 337746368,
+        "disabled": false
+      },
+      "dungeons_arise:illager_campsite": {
+        "spacing": 60,
+        "separation": 30,
+        "salt": 372632832,
+        "disabled": false
+      },
+      "dungeons_arise:illager_castle": {
+        "spacing": 160,
+        "separation": 60,
+        "salt": 112436256,
+        "disabled": false
+      },
+      "dungeons_arise:illager_corsair": {
+        "spacing": 64,
+        "separation": 48,
+        "salt": 777463552,
+        "disabled": false
+      },
+      "dungeons_arise:illager_fort": {
+        "spacing": 160,
+        "separation": 60,
+        "salt": 563835968,
+        "disabled": false
+      },
+      "dungeons_arise:illager_galley": {
+        "spacing": 50,
+        "separation": 30,
+        "salt": 995537216,
+        "disabled": false
+      },
+      "dungeons_arise:illager_hall": {
+        "spacing": 230,
+        "separation": 90,
+        "salt": 336452896,
+        "disabled": false
+      },
+      "dungeons_arise:illager_windmill": {
+        "spacing": 50,
+        "separation": 45,
+        "salt": 277746720,
+        "disabled": false
+      },
+      "dungeons_arise:infested_temple": {
+        "spacing": 140,
+        "separation": 100,
+        "salt": 297069568,
+        "disabled": false
+      },
+      "dungeons_arise:jungle_tree_house": {
+        "spacing": 160,
+        "separation": 140,
+        "salt": 240573264,
+        "disabled": false
+      },
+      "dungeons_arise:lighthouse": {
+        "spacing": 100,
+        "separation": 90,
+        "salt": 283742688,
+        "disabled": false
+      },
+      "dungeons_arise:merchant_campsite": {
+        "spacing": 60,
+        "separation": 40,
+        "salt": 68534680,
+        "disabled": false
+      },
+      "dungeons_arise:mining_system": {
+        "spacing": 90,
+        "separation": 60,
+        "salt": 263511744,
+        "disabled": false
+      },
+      "dungeons_arise:monastery": {
+        "spacing": 150,
+        "separation": 90,
+        "salt": 182626176,
+        "disabled": false
+      },
+      "dungeons_arise:mushroom_house": {
+        "spacing": 80,
+        "separation": 40,
+        "salt": 347766176,
+        "disabled": false
+      },
+      "dungeons_arise:mushroom_mines": {
+        "spacing": 80,
+        "separation": 40,
+        "salt": 98376176,
+        "disabled": false
+      },
+      "dungeons_arise:mushroom_village": {
+        "spacing": 60,
+        "separation": 20,
+        "salt": 573733440,
+        "disabled": false
+      },
+      "dungeons_arise:plague_asylum": {
+        "spacing": 240,
+        "separation": 200,
+        "salt": 637271616,
+        "disabled": false
+      },
+      "dungeons_arise:scorched_mines": {
+        "spacing": 120,
+        "separation": 90,
+        "salt": 1332446336,
+        "disabled": false
+      },
+      "dungeons_arise:shiraz_palace": {
+        "spacing": 160,
+        "separation": 140,
+        "salt": 888377728,
+        "disabled": false
+      },
+      "dungeons_arise:small_blimp": {
+        "spacing": 80,
+        "separation": 60,
+        "salt": 446553376,
+        "disabled": false
+      },
+      "dungeons_arise:small_prairie_house": {
+        "spacing": 25,
+        "separation": 10,
+        "salt": 73563520,
+        "disabled": false
+      },
+      "dungeons_arise:thornborn_towers": {
+        "spacing": 80,
+        "separation": 70,
+        "salt": 292377152,
+        "disabled": false
+      },
+      "dungeons_arise:typhon": {
+        "spacing": 60,
+        "separation": 50,
+        "salt": 357769440,
+        "disabled": false
+      },
+      "dungeons_arise:undead_pirate_ship": {
+        "spacing": 60,
+        "separation": 40,
+        "salt": 952444288,
+        "disabled": false
+      },
+      "dungeons_arise:wishing_well": {
+        "spacing": 40,
+        "separation": 30,
+        "salt": 465869312,
+        "disabled": false
+      },
       "dungeons_plus:bigger_dungeon": {
         "spacing": 12,
         "separation": 5,
@@ -373,6 +595,12 @@
         "salt": 1436736640,
         "disabled": false
       },
+      "repurposed_structures:mineshaft_swamp": {
+        "spacing": 1,
+        "separation": 0,
+        "salt": 2037177728,
+        "disabled": false
+      },
       "repurposed_structures:mineshaft_swamp_forest": {
         "spacing": 1,
         "separation": 0,
@@ -577,6 +805,12 @@
         "salt": 2072979584,
         "disabled": false
       },
+      "repurposed_structures:stronghold_end": {
+        "spacing": 130,
+        "separation": 65,
+        "salt": 1922886400,
+        "disabled": false
+      },
       "repurposed_structures:stronghold_nether": {
         "spacing": 85,
         "separation": 42,
@@ -653,6 +887,12 @@
         "spacing": 31,
         "separation": 15,
         "salt": 2010876032,
+        "disabled": false
+      },
+      "repurposed_structures:village_mushroom": {
+        "spacing": 24,
+        "separation": 12,
+        "salt": 1150624896,
         "disabled": false
       },
       "repurposed_structures:village_oak": {
@@ -830,7 +1070,12 @@
       "continentType": "MULTI",
       "continentShape": "NATURAL",
       "continentScale": 1963,
-      "continentJitter": 0.699
+      "continentJitter": 0.699,
+      "continentSkipping": 0.25,
+      "continentSizeVariance": 0.25,
+      "continentNoiseOctaves": 5,
+      "continentNoiseGain": 0.259,
+      "continentNoiseLacunarity": 4.328
     },
     "controlPoints": {
       "deepOcean": 0.056,


### PR DESCRIPTION
This wont affect anything in current or new worlds as it updates itself whenever someone starts a world and sees new structures that it doesn't have, we just haven't updated it on the repo in a minute

fixes #4349 