### PR TITLE
update restrictions translation strings

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -814,7 +814,7 @@
     "item.kubejs.molten_nitro_bucket": "Molten Nitro Crystal Bucket",
     "item.kubejs.molten_spirited_bucket": "Molten Spirited Crystal Bucket",
 
-    "gamestage.enigmatica.restrictions.master_blood_orb": "May only be placed in the Undergarden. Craft a Master Blood Orb to lift this restriction.",
-    "gamestage.enigmatica.restrictions.hellfire_forge": "May only be placed in the Nether and only after crafting a Hellfire Forge.",
-    "gamestage.enigmatica.restrictions.red_chalk": "May only be placed in Atum. Craft Red Chalk to lift this restriction."
+    "gamestage.enigmatica.restrictions.master_blood_orb": "May only be used in the Undergarden. Craft a Master Blood Orb to lift this restriction.",
+    "gamestage.enigmatica.restrictions.hellfire_forge": "May only be used in the Nether and only after crafting a Hellfire Forge.",
+    "gamestage.enigmatica.restrictions.red_chalk": "May only be used in Atum. Craft Red Chalk to lift this restriction."
 }


### PR DESCRIPTION
Restrictions now blocks accessing the gui of a placed block unless the conditions are met. Updated message to match.

Requires an update to Restrictions before launch. (v1.4)