### PR TITLE
[Expert] Tier 2 Magic dependency fixes

### DIFF
--- a/config/ftbquests/quests/chapters/magic__adept.snbt
+++ b/config/ftbquests/quests/chapters/magic__adept.snbt
@@ -394,7 +394,6 @@
 			dependencies: [
 				"5602E77D09C84F56"
 				"43D3D565E295FA5D"
-				"57FFFBB68F2655C1"
 			]
 			id: "7BA120BEA495D354"
 			tasks: [
@@ -622,7 +621,7 @@
 			y: -0.5d
 			shape: "diamond"
 			description: ["Effective as it may be some practitioners find the practice of sacrificing other beings distasteful. The Adept learns early on to give of their own blood as sacrifice, and to draw upon the earth for healing. "]
-			dependencies: ["0000000000000FCD"]
+			dependencies: ["7BA120BEA495D354"]
 			id: "57FFFBB68F2655C1"
 			tasks: [{
 				id: "19014A262532EB8F"


### PR DESCRIPTION
reverses sacrificial knife dependency so it's no longer required for progression in the quests, since it's not required for actual progression