### PR TITLE
[Expert] Allow automation to work with Occultism

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -16,7 +16,7 @@ onEvent('server.datapack.high_priority', (event) => {
         }
     ];
 
-    let restricted_occultism_blocks = ['occultism:golden_sacrificial_bowl', 'occultism:sacrificial_bowl'];
+    let restricted_occultism_blocks = ['occultism:sacrificial_bowl'];
     restricted_occultism_blocks.forEach((block) => {
         restrictions.push({
             type: 'or',


### PR DESCRIPTION
Recent changes to Re-Restricted are blocking fake players from activating the bowl.
Previously removed chalk from the restriction to allow fake players to draw the pentacles. Now removing the golden bowl so they can activate them.

Still won't be able to perform a ritual without placing some regular bowls, however, so this maintains the restriction, but opens up automation.

Should resolve #4425