### PR TITLE
Blacklist arcane pedestal from tinkers crafting station inventory

### DIFF
--- a/kubejs/data/tconstruct/tags/tile_entity_types/crafting_station_blacklist.json
+++ b/kubejs/data/tconstruct/tags/tile_entity_types/crafting_station_blacklist.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "ars_nouveau:arcane_pedestal"
+    ]
+}


### PR DESCRIPTION
fixes #4444, couldn't figure out how to do it through a tag event, custom tag event didn't seem to be working, but this works fine and can add to it here if other stuff shows up in the future.

https://gyazo.com/8271dde54cac80b7463e39b3ea685dc5
video of the issue, pretty good one lol