### PR TITLE
Quest fixes - allow any mechanical piston in Create, fix typo in Expert quests

### DIFF
--- a/config/ftbquests/quests/chapters/create.snbt
+++ b/config/ftbquests/quests/chapters/create.snbt
@@ -1255,7 +1255,23 @@
 			tasks: [{
 				id: "0000000000000D2E"
 				type: "item"
-				item: "create:mechanical_piston"
+				title: "Mechanical Piston"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "create:mechanical_piston"
+								Count: 1b
+							}
+							{
+								id: "create:sticky_mechanical_piston"
+								Count: 1b
+							}
+						]
+					}
+				}
 			}]
 			rewards: [
 				{

--- a/config/ftbquests/quests/chapters/expert__tier_1_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_1_wip.snbt
@@ -471,6 +471,7 @@
 				{
 					id: "4635A9AA2AFB35C4"
 					type: "item"
+					title: "xNet Cables"
 					item: {
 						id: "itemfilters:or"
 						Count: 1b


### PR DESCRIPTION
Quest fixes - allow any mechanical piston in Create, fix typo in Expert quests