### PR TITLE
Disables flying structures and infested temple

### DIFF
--- a/config/when-dungeons-arise-common.toml
+++ b/config/when-dungeons-arise-common.toml
@@ -402,7 +402,7 @@
 
 		["When Configurations Arise"."Haunted Structures"."Infested Temple Spawning Settings"]
 			#Whether Infested Temples generate on your worlds or not.
-			infestedTempleGenerates = true
+			infestedTempleGenerates = false
 			#Maximum separation between Infested Temples (in chunks).
 			#Range: 0 ~ 1000000
 			infestedTempleSpacing = 140
@@ -444,7 +444,7 @@
 
 		["When Configurations Arise"."Eerie Structures"."Heavenly Rider Spawning Settings"]
 			#Whether Heavenly Riders generate on your worlds or not.
-			heavenlyRiderGenerates = true
+			heavenlyRiderGenerates = false
 			#Maximum separation between Heavenly Riders (in chunks).
 			#Range: 0 ~ 1000000
 			heavenlyRiderSpacing = 180
@@ -464,7 +464,7 @@
 
 		["When Configurations Arise"."Eerie Structures"."Heavenly Conqueror Spawning Settings"]
 			#Whether Heavenly Conquerors generate on your worlds or not.
-			heavenlyConquerorGenerates = true
+			heavenlyConquerorGenerates = false
 			#Maximum separation between Heavenly Conquerors (in chunks).
 			#Range: 0 ~ 1000000
 			heavenlyConquerorSpacing = 230
@@ -484,7 +484,7 @@
 
 		["When Configurations Arise"."Eerie Structures"."Heavenly Challenger Spawning Settings"]
 			#Whether Heavenly Challengers generate on your worlds or not.
-			heavenlyChallengerGenerates = true
+			heavenlyChallengerGenerates = false
 			#Maximum separation between Heavenly Challengers (in chunks).
 			#Range: 0 ~ 1000000
 			heavenlyChallengerSpacing = 340


### PR DESCRIPTION
These structures have a possibility of partially generating above build limit causing watchdog crashes in terraforged worlds