### PR TITLE
Remove Reinforced Stone from PNC Basic Tank

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/shaped.js
@@ -118,11 +118,11 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'pneumaticcraft:small_tank',
-            pattern: ['AAA', 'CBC', 'AAA'],
+            pattern: ['AAA', 'BCB', 'AAA'],
             key: {
-                A: 'pneumaticcraft:reinforced_stone_slab',
+                A: 'create:andesite_alloy',
                 B: '#thermal:glass/hardened',
-                C: 'pneumaticcraft:reinforced_brick_wall'
+                C: 'mekanism:basic_fluid_tank'
             },
             id: 'pneumaticcraft:small_tank'
         },


### PR DESCRIPTION
Reduces cost of the basic PNC tank - it's useable in tables that require buckets of fluid, so this is a big boon to early crafting.

Tank Recipe:
![image](https://user-images.githubusercontent.com/13169307/160167619-8dfed4dc-8e7d-4530-b682-12e0795ec438.png)
