### PR TITLE
Make Blood available from trees again

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/fluid_extractor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/fluid_extractor.js
@@ -3,28 +3,30 @@ onEvent('recipes', (event) => {
         treeCategories.trees.forEach((tree) => {
             let strippedLog = getStrippedLogFrom(tree.trunk);
             if (tree.sap) {
-                //Extract at full rate from Logs
-                event
-                    .custom({
-                        input: { item: tree.trunk },
-                        result: strippedLog,
-                        breakChance: 0.005,
-                        output: `{FluidName:"${tree.sap}",Amount:${tree.rate.dead}}`,
-                        defaultRecipe: false,
-                        type: 'industrialforegoing:fluid_extractor'
-                    })
-                    .id(`industrialforegoing:fluid_extractor/${tree.trunk.replace(':', '/')}`);
-                // Extract at half rate from Stripped Logs
-                event
-                    .custom({
-                        type: 'industrialforegoing:fluid_extractor',
-                        input: { item: strippedLog },
-                        result: 'minecraft:air',
-                        breakChance: 0.005,
-                        output: `{FluidName:"${tree.sap}",Amount:${tree.rate.dead / 2}}`,
-                        defaultRecipe: false
-                    })
-                    .id(`industrialforegoing:fluid_extractor/${strippedLog.replace(':', '/')}`);
+                if (tree.rate.dead > 0) {
+                    //Extract at full rate from Logs
+                    event
+                        .custom({
+                            input: { item: tree.trunk },
+                            result: strippedLog,
+                            breakChance: 0.005,
+                            output: `{FluidName:"${tree.sap}",Amount:${tree.rate.dead}}`,
+                            defaultRecipe: false,
+                            type: 'industrialforegoing:fluid_extractor'
+                        })
+                        .id(`industrialforegoing:fluid_extractor/${tree.trunk.replace(':', '/')}`);
+                    // Extract at half rate from Stripped Logs
+                    event
+                        .custom({
+                            type: 'industrialforegoing:fluid_extractor',
+                            input: { item: strippedLog },
+                            result: 'minecraft:air',
+                            breakChance: 0.005,
+                            output: `{FluidName:"${tree.sap}",Amount:${tree.rate.dead / 2}}`,
+                            defaultRecipe: false
+                        })
+                        .id(`industrialforegoing:fluid_extractor/${strippedLog.replace(':', '/')}`);
+                }
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
@@ -2,15 +2,17 @@ onEvent('recipes', (event) => {
     treeRegistry.forEach((treeCategories) => {
         treeCategories.trees.forEach((tree) => {
             if (tree.sap) {
-                event.custom({
-                    type: 'thermal:tree_extractor',
-                    trunk: tree.trunk,
-                    leaves: tree.leaf,
-                    result: {
-                        fluid: tree.sap,
-                        amount: tree.rate.living
-                    }
-                });
+                if (tree.rate.living > 0) {
+                    event.custom({
+                        type: 'thermal:tree_extractor',
+                        trunk: tree.trunk,
+                        leaves: tree.leaf,
+                        result: {
+                            fluid: tree.sap,
+                            amount: tree.rate.living
+                        }
+                    });
+                }
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
@@ -747,7 +747,7 @@ const treeRegistry = [
                 trunk: 'architects_palette:twisted_log',
                 leaf: 'architects_palette:twisted_leaves',
                 substrate: 'dirt',
-                sap: 'thermal:resin',
+                sap: 'tconstruct:blood',
                 rate: { living: 25, dead: 4 }
             },
             {
@@ -1105,7 +1105,7 @@ const treeRegistry = [
                 extraDecoration: 'undergarden:blood_mushroom_globule',
                 substrate: 'deepturf',
                 sap: 'tconstruct:blood',
-                rate: { living: 25, dead: 4 }
+                rate: { living: 0, dead: 4 }
             },
 
             {
@@ -1174,7 +1174,7 @@ const treeRegistry = [
                 fruit: 'tconstruct:ichor_slime_ball',
                 substrate: 'slimy_dirt',
                 sap: 'tconstruct:blood',
-                rate: { living: 25, dead: 4 }
+                rate: { living: 0, dead: 4 }
             }
         ]
     }


### PR DESCRIPTION
The arboreal extractor can't recognize the two current 'shroom' trees as valid for blood extraction. So they've been removed from it. 

Instead, the Twisted Tree (gained by tossing any sapling through a nether portal) can be used instead: 

![image](https://user-images.githubusercontent.com/9543430/160303815-909db558-1f8b-4b75-98be-3d98df3eec91.png)

Tinkers Bloodshroom and Undergarden's Blood Mushroom may still have blood extracted via IF's fluid extractor, however. 

Resolves #4499