### PR TITLE
Explicitly state in the Expert quests how to obtain rock crystals. Remove superfluous Linking Tool from Astral Quests. 

### DIFF
--- a/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
+++ b/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
@@ -813,22 +813,14 @@
 					item: "astralsorcery:wand"
 				}
 			]
-			rewards: [
-				{
-					id: "0000000000000BBC"
-					type: "item"
-					title: "Linking Tool"
-					item: "astralsorcery:linking_tool"
-				}
-				{
-					id: "0000000000000C5F"
-					type: "command"
-					title: "Scavenger's Delight"
-					icon: "kubejs:scavengers_delight"
-					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight"
-					player_command: false
-				}
-			]
+			rewards: [{
+				id: "0000000000000C5F"
+				type: "command"
+				title: "Scavenger's Delight"
+				icon: "kubejs:scavengers_delight"
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight"
+				player_command: false
+			}]
 		}
 		{
 			x: 5.0d

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -500,7 +500,7 @@
 			description: [
 				"A time-honored tradition, dowsing has its origins deep in the hazy past of early magic, predating even written history. Though it’s more commonly known in terms of water dowsing, it was once used to find all manner of things, from plants, to minerals, or even strong magical field lines. "
 				""
-				"The Resonating Wand is particularly suited to finding Rock Crystals deep in the earth. "
+				"The Resonating Wand is particularly suited to finding Rock Crystals deep in the earth. Hold it at night and the locations of these crystals will be revealed by soft lights."
 			]
 			dependencies: ["4C5CCC780A4B07A7"]
 			id: "269CB5E2F7130224"


### PR DESCRIPTION
Explicitly state in the Expert quests how to obtain rock crystals. Remove superfluous Linking Tool from Astral Quests. 