### PR TITLE
add tconstruct:slime_crystal tag to slime crystals

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/tconstruct/crystals.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/tconstruct/crystals.js
@@ -1,0 +1,3 @@
+onEvent('item.tags', (event) => {
+    event.get('tconstruct:slime_crystal').add(/tconstruct:\w+_slime_crystal/);
+});


### PR DESCRIPTION
Tags tinkers slime crystals so they can be used in attribute filters. 

![image](https://user-images.githubusercontent.com/283805/161197571-217c4d2a-39d5-4c38-a5ee-950fbd24b8b8.png)
