### PR TITLE
Disable Mob Fleeing for Small Ships

### DIFF
--- a/config/smallships-common.toml
+++ b/config/smallships-common.toml
@@ -81,7 +81,7 @@ Version = 9
 	#----Should Ships Make WaterMobs flee?----
 	#	(takes effect after restart)
 	#	default: true
-	WaterMobFlee = true
+	WaterMobFlee = false
 	#
 	#----Ship Zoom.----
 	#	(takes effect after restart)


### PR DESCRIPTION
This option is causing any Little Logistics tugs nearby to veer off course and get stuck. Seems like an easy win to disable. The only downside I see is potentially more mobs getting caught in the boat, much like vanilla boats.