### PR TITLE
Fix #4580

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -696,7 +696,7 @@ onEvent('recipes', (event) => {
                 'quark:gold_bars',
                 'quark:gold_bars',
                 'betterendforge:terminite_anvil',
-                'betterendforge:terminite_hammer',
+		Item.of('betterendforge:terminite_hammer', '{Damage:0]}').weakNBT(),
                 'minecraft:blast_furnace',
                 'supplementaries:bellows',
                 '#forge:storage_blocks/coal',


### PR DESCRIPTION
Fix Auto-repair lost trinket makes the terminite Hammer unusable to summon blacksmithing familiar
By Tarod7

fix #4580