### PR TITLE
Temporary fix for missing Source Berry Roll recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
@@ -108,6 +108,16 @@ onEvent('recipes', (event) => {
             ],
             output: Item.of('kubejs:blast_brick_blend', 4),
             id: `${id_prefix}blast_brick_blend`
+        },
+        {
+            inputs: [
+                'farmersdelight:wheat_dough',
+                'farmersdelight:wheat_dough',
+                'farmersdelight:wheat_dough',
+                'ars_nouveau:mana_berry'
+            ],
+            output: Item.of('ars_nouveau:source_berry_roll', 3),
+            id: `${id_prefix}source_berry_roll`
         }
     ];
 


### PR DESCRIPTION
Issue #4040 has been open and under investigation for a few months now, and while this doesn't fix the underlying issue cause I can't for the life of me figure out what's disabling the normal shapeless mixing recipe, this gives a way to easily automate source berry rolls in the meantime.