### PR TITLE
[Expert] Add Wandering Trader summon

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
@@ -234,6 +234,18 @@ onEvent('recipes', (event) => {
             aura: 30000,
             time: 40,
             id: `${id_prefix}nautilus`
+        },
+        {
+            inputs: [
+                'naturesaura:birth_spirit',
+                '#botania:runes/asgard',
+                '#botania:runes/vanaheim',
+                'bloodmagic:seersigil'
+            ],
+            entity: 'minecraft:wandering_trader',
+            aura: 2000000,
+            time: 400,
+            id: `${id_prefix}wandering_trader`
         }
     ];
 


### PR DESCRIPTION
Some people appear to be getting terribly unlucky with this guy and need it for the Attunement Altar. This creates a late game way to summon one to get over the hump.

![image](https://user-images.githubusercontent.com/9543430/163196265-5e29d23c-ca6d-4927-b420-2f838fab0ec2.png)