### PR TITLE
[Expert] Remove dependency on IE coke oven

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_1_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_1_wip.snbt
@@ -234,7 +234,7 @@
 				id: "45F596F7AFA8BFFF"
 				type: "item"
 				item: "immersiveengineering:cokebrick"
-				count: 27L
+				count: 17L
 			}]
 		}
 		{

--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -94,7 +94,7 @@
 				{
 					id: "000000000000000C"
 					type: "item"
-					title: "Any forge:gems/coal_coke"
+					title: "Any Coal Coke"
 					item: {
 						id: "itemfilters:tag"
 						Count: 1b

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/blast_furnace.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/blast_furnace.js
@@ -1,0 +1,47 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/blast_furnace/';
+    const recipes = [
+        {
+            input: '#forge:slimeball/earth',
+            output: 'tconstruct:earth_slime_crystal',
+            slag: 'thermal:slag',
+            time: 100,
+            id: `${id_prefix}earth_slime_crystal`
+        },
+        {
+            input: '#forge:slimeball/sky',
+            output: 'tconstruct:sky_slime_crystal',
+            slag: 'thermal:slag',
+            time: 100,
+            id: `${id_prefix}sky_slime_crystal`
+        },
+        {
+            input: '#forge:slimeball/ender',
+            output: 'tconstruct:ender_slime_crystal',
+            slag: 'thermal:slag',
+            time: 100,
+            id: `${id_prefix}ender_slime_crystal`
+        },
+        {
+            input: '#forge:slimeball/ichor',
+            output: 'tconstruct:ichor_slime_crystal',
+            slag: 'thermal:slag',
+            time: 100,
+            id: `${id_prefix}ichor_slime_crystal`
+        },
+        {
+            input: 'industrialforegoing:pink_slime',
+            output: 'materialis:pink_slime_crystal',
+            slag: 'thermal:slag',
+            time: 100,
+            id: `${id_prefix}pink_slime_crystal`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.recipes.immersiveengineering
+            .blast_furnace(recipe.output, recipe.input, recipe.slag)
+            .time(recipe.time)
+            .id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -49,18 +49,6 @@ onEvent('recipes', (event) => {
             },
             id: 'astralsorcery:observatory'
         },
-        /*{
-            output: Item.of('immersiveengineering:blastbrick', 9),
-            pattern: ['ADA', 'CBC', 'AEA'],
-            key: {
-                C: 'immersiveengineering:cokebrick',
-                B: 'minecraft:blast_furnace',
-                A: 'minecraft:red_nether_bricks',
-                D: 'thermal:fire_tnt',
-                E: '#forge:storage_blocks/coal_coke'
-            },
-            id: 'immersiveengineering:crafting/blastbrick'
-        },*/
         {
             output: 'refinedstorage:controller',
             pattern: ['ACACA', 'CDBDC', 'AFEFA', 'CDBDC', 'ACACA'],
@@ -769,6 +757,19 @@ onEvent('recipes', (event) => {
                 G: '#industrialforegoing:machine_frame/supreme'
             },
             id: `${id_prefix}industrial_deuterium_plant_controller`
+        },
+        {
+            output: 'thermal:machine_pyrolyzer',
+            pattern: ['AAAAA', 'AACAA', 'AADAA', 'AEFEA', 'AGGGA'],
+            key: {
+                A: 'immersiveengineering:cokebrick',
+                C: 'thermal:machine_frame',
+                D: Item.of('thermal:fluid_cell').ignoreNBT(),
+                E: '#forge:gears/constantan',
+                F: 'botania:blaze_block',
+                G: 'immersiveengineering:coil_mv'
+            },
+            id: 'thermal:machine_pyrolyzer'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/pyrolyzer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/pyrolyzer.js
@@ -1,0 +1,40 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/thermal/pyrolyzer/';
+    const recipes = [
+        {
+            input: 'minecraft:coal',
+            outputs: ['emendatusenigmatica:coke_gem', 'thermal:tar', Fluid.of('immersiveengineering:creosote', 250)],
+            energy: 12000,
+            id: 'thermal:machine/pyrolyzer/pyrolyzer_coal'
+        },
+        {
+            input: 'minecraft:coal_block',
+            outputs: [
+                'emendatusenigmatica:coke_block',
+                'thermal:tar_block',
+                Fluid.of('immersiveengineering:creosote', 250 * 9)
+            ],
+            energy: 12000 * 8,
+            id: `${id_prefix}coke_block_from_coal_block`
+        },
+        {
+            input: '#minecraft:logs',
+            outputs: ['minecraft:charcoal', Fluid.of('immersiveengineering:creosote', 125)],
+            energy: 6000,
+            id: 'thermal:machine/pyrolyzer/pyrolyzer_logs'
+        },
+        {
+            input: '#forge:gems/bitumen',
+            outputs: ['emendatusenigmatica:coke_gem', 'thermal:tar', Fluid.of('thermal:heavy_oil', 50)],
+            energy: 12000,
+            id: 'thermal:machine/pyrolyzer/pyrolyzer_bitumen'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.recipes.thermal.pyrolyzer(recipe.outputs, recipe.input).energy(recipe.energy).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_input.js
@@ -5,16 +5,6 @@ onEvent('recipes', (event) => {
 
     const recipes = [
         {
-            replaceTarget: { id: 'thermal:machine_pyrolyzer' },
-            toReplace: 'thermal:machine_frame',
-            replaceWith: Item.of('thermal:fluid_cell').ignoreNBT()
-        },
-        {
-            replaceTarget: { id: 'thermal:machine_pyrolyzer' },
-            toReplace: '#forge:netherbricks',
-            replaceWith: 'immersiveengineering:blastbrick'
-        },
-        {
             replaceTarget: { id: 'thermal:machine_bottler' },
             toReplace: 'thermal:machine_frame',
             replaceWith: 'thermal:fluid_cell_frame'


### PR DESCRIPTION
It's slow, you use it once, and then you're done forever. No point.

Pyrolizer will take it's place instead: 
![image](https://user-images.githubusercontent.com/9543430/163440218-182325d7-805d-4cb2-b81d-243601e3bd05.png)
