### PR TITLE
Remove tags from Atum crystal glass/panes in expert

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/tags/items/forge/glass.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/tags/items/forge/glass.js
@@ -1,0 +1,11 @@
+onEvent('item.tags', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    event
+        .removeAllTagsFrom('atum:crystal_glass');
+    colors.forEach((color) => {
+        event
+            .removeAllTagsFrom('atum:' + color + '_stained_crystal_glass')
+    })
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/tags/items/forge/glass_panes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/tags/items/forge/glass_panes.js
@@ -1,0 +1,11 @@
+onEvent('item.tags', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    event
+        .removeAllTagsFrom('atum:crystal_glass_pane');
+    colors.forEach((color) => {
+        event
+            .removeAllTagsFrom('atum:' + color + '_stained_crystal_glass_pane')
+    })
+});


### PR DESCRIPTION
With Atum crystal glass/panes and its stained variants being more expensive in expert and used in specific recipes, it makes sense to not have them in the glass tag where it might get used instead of cheaper glass in recipes. Like when using JEI autofill in occultism storage.

Removed from all tags because one of the other tags it has is being added to forge:glass causing it to get re-added after removal.