### PR TITLE
Recipes to drain resourceful honey bottles to thermal centrifuge

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge.js
@@ -12,6 +12,23 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}meat`
         }
     ];
+    
+    honeyVarieties.forEach((honeyVariety) => {
+        if(honeyVariety == 'resourcefulbees:honey') {
+            return;
+        }
+
+        let honey = honeyVariety.split(':')[1];
+        recipes.push({
+            input: Item.of(`${honeyVariety}_bottle`),
+            outputs: [
+                Item.of('minecraft:glass_bottle'),
+                Fluid.of(honeyVariety, 250)
+            ],
+            id: `${id_prefix}honey/${honey}`
+        });
+    });
+    
     recipes.forEach((recipe) => {
         event.recipes.thermal.centrifuge(recipe.outputs, recipe.input).id(recipe.id);
     });


### PR DESCRIPTION
By default the Thermal centrifugal separator can drain honey from vanilla honey bottles.
This change makes it possible to also drain the resourceful honey bottles in it.

The Create drain is already capable of doing this without using power, so this shouldn't break expert mode balancing and makes honey post processing more convenient - no flying glass bottles.