### PR TITLE
[Expert] Lower starlight crafting requirements for some crafts in the early tiers of Astral Sorcery

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
@@ -94,7 +94,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 0,
             duration: 100,
-            starlight: 700,
+            starlight: 500,
             effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
             id: `${id_prefix}animal_spawner`
         },
@@ -114,7 +114,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 0,
             duration: 100,
-            starlight: 700,
+            starlight: 500,
             effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
             id: `${id_prefix}runic_altar`
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_1_starlight.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_1_starlight.js
@@ -58,7 +58,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 1,
             duration: 200,
-            starlight: 1900,
+            starlight: 1400,
             effects: [
                 'astralsorcery:built_in_effect_discovery_central_beam',
                 'astralsorcery:gateway_edge',
@@ -90,7 +90,7 @@ onEvent('recipes', (event) => {
             output: Item.of('astralsorcery:shifting_star'),
             altar_type: 1,
             duration: 200,
-            starlight: 1600,
+            starlight: 1400,
             pattern: ['A___A', '_ECB_', '_CDC_', '_BCE_', 'A___A'],
             key: {
                 A: { tag: 'forge:gems/niotic' },
@@ -130,7 +130,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 1,
             duration: 200,
-            starlight: 1600,
+            starlight: 1400,
             effects: [
                 'astralsorcery:pillar_sparkle',
                 'astralsorcery:built_in_effect_discovery_central_beam',
@@ -165,7 +165,7 @@ onEvent('recipes', (event) => {
             output: Item.of('cookingforblockheads:sink'),
             altar_type: 1,
             duration: 200,
-            starlight: 1400,
+            starlight: 1000,
             pattern: ['A___A', '_BCB_', '_GEG_', '_GFG_', 'D___D'],
             key: {
                 A: { tag: 'botania:runes/water' },
@@ -242,7 +242,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 1,
             duration: 200,
-            starlight: 1600,
+            starlight: 1400,
             effects: ['astralsorcery:pillar_sparkle'],
             id: 'astralsorcery:altar/attunement_altar'
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_2_celestial.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_2_celestial.js
@@ -36,7 +36,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 2,
             duration: 400,
-            starlight: 3800,
+            starlight: 3500,
             recipe_class: 'astralsorcery:trait_upgrade',
             effects: [
                 'astralsorcery:built_in_effect_constellation_finish',
@@ -91,7 +91,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 2,
             duration: 400,
-            starlight: 3800,
+            starlight: 3500,
             effects: [
                 'astralsorcery:built_in_effect_constellation_finish',
                 'astralsorcery:built_in_effect_discovery_central_beam',
@@ -121,7 +121,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 2,
             duration: 400,
-            starlight: 3800,
+            starlight: 3500,
             effects: [
                 'astralsorcery:built_in_effect_constellation_finish',
                 'astralsorcery:pillar_sparkle',
@@ -302,7 +302,7 @@ onEvent('recipes', (event) => {
             },
             altar_type: 2,
             duration: 400,
-            starlight: 3800,
+            starlight: 3500,
             effects: [
                 'astralsorcery:built_in_effect_constellation_finish',
                 'astralsorcery:built_in_effect_discovery_central_beam',


### PR DESCRIPTION
These are proving too difficult to craft reliably. It is intended that the player need to maximize starlight in some cases, however, especially in some of the earlier crafts, it's not really feasible.