### PR TITLE
Flip the default recipe for the redstone flux coil

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
@@ -48,7 +48,7 @@ onEvent('recipes', (event) => {
         },
         {
             output: Item.of('thermal:rf_coil'),
-            pattern: ['CA ', 'ABA', ' AC'],
+            pattern: [' AC', 'ABA', 'CA '],
             key: {
                 A: '#forge:dusts/redstone',
                 B: '#forge:rods/gold_copper',


### PR DESCRIPTION
> this pull request flips the default recipe shown in order to have the gold nuggets & rod line up with the item's texture.

before: 
![Screen Shot 2022-04-18 at 18 24 09](https://user-images.githubusercontent.com/3179271/163839339-3e5bd7a7-1d19-4223-ad87-8f8e02481e4a.png)

after:
![Screen Shot 2022-04-18 at 18 24 31](https://user-images.githubusercontent.com/3179271/163839387-a47fac9f-4bfb-4a20-9b80-2df2be7d8fc2.png)

you could already do it this way (jei just didn't suggest it), now that the recipe is flipped the old one isn't suggested & still works (aka: backwards compatible with all prior automated craftings, this is not an automation breaking change 😗)