### PR TITLE
Require just one laser for the expert drill quest

### DIFF
--- a/config/ftbquests/quests/chapters/tech_t3.snbt
+++ b/config/ftbquests/quests/chapters/tech_t3.snbt
@@ -89,7 +89,6 @@
 					id: "0536AAB566704AC9"
 					type: "item"
 					item: "industrialforegoing:laser_drill"
-					count: 4L
 				}
 				{
 					id: "5703696A09A152C1"


### PR DESCRIPTION
While four or more lasers is ideal, you only need one laser and one base in order to progress (e.g. when lacking resources or automation for more lasers), on the server i'm playing on we obtained one of each bucket so we could progress quickly towards the advanced assembly table, but the questing progression could not keep up since it first wants to see four of em:

![the quest node with both buckets in the background](https://cdn.discordapp.com/attachments/858470513817813012/966039582984536174/Screen_Shot_2022-04-19_at_20.15.03.png)