### PR TITLE
Mention that steady growth powder can prevent flower spam

### DIFF
--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -1132,7 +1132,7 @@
 				""
 				"● Bountiful Core - Stone and Netherrack are converted to ore with the appropriate Aura type."
 				""
-				"● Steady Growth - Plants growth will no longer be boosted by Aura."
+				"● Steady Growth - The growth of crops, plants, and flowers will no longer be boosted by Aura."
 				""
 				"● Fertility - Passive Animals will breed when able."
 				""


### PR DESCRIPTION
![Screen Shot 2022-04-22 at 20 35 05](https://user-images.githubusercontent.com/3179271/164774451-e49fc3c9-7c5a-4352-869c-983f767e7d0d.png)

I've had a chat with @Ellpeck today about which powder was responsible for (preventing) flowers from popping up everywhere where there is more than 3/4th aura:
![flowers everywhere](https://cdn.discordapp.com/attachments/967100103229861978/967103045966131260/2022-04-22_18.27.49.png)

In a nutshell it wasn't documented anywhere since its a slight bug, the aura doesn't grow on vanilla grass blocks only, and it is not likely to be fixed in (or backported to) 1.16.5: https://github.com/Ellpeck/NaturesAura/blob/1.16/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java#L75-L79

Essentially any non-vanilla grass block (e.g. in my base overgrown stone is to blame) can cause itself and nearby vanilla grass blocks to have flowers spammed on them, causing quite the visual mess that can't be cleared unless you know this powder can stop it.

So this pull requests updates the quest node text to mention flowers, which should be enough for anyone to connect the dots when facing unwanted flowers that this is the powder you'll need.

Personally i have set `plantBoostEffect` to `false` in the `naturesaura-common.toml` since i didn't feel like placing powder everywhere the creational catalyst could reach & there are already plenty of crop boost options (fertile soil / fertilizers / argicarnation / probably some ars thing too / pnc crop supports / etc), it might be something to consider changing too since it might (sure did with me) prevent people from filling their aura above 3/4th to avoid flowers, which makes them more susceptible to low aura issues, and make it harder to charge aura belts/troves.

> Left on draft mode to encourage discussion regarding the course of action. 