### PR TITLE
Make "effect powders" node depend on "ebb and flow" instead

### DIFF
--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -1139,7 +1139,7 @@
 				"● No Storage - Your Aura Cache or Trove will not charge in the area."
 			]
 			hide_dependency_lines: true
-			dependencies: ["00000000000002C7"]
+			dependencies: ["00000000000002C2"]
 			id: "0000000000000339"
 			tasks: [
 				{


### PR DESCRIPTION
Currently it's dependency is the creational catalyst  (which is rather expensive in expert mode), but aura can already cause effects with 3/4th of a bar instead of requiring it to be overflowing, this pull request swaps the dependency to the ancient sapling node, which aura refilling is cached after so the power node doesn't stay needlessly greyed out.

![2022-04-22_20 55 37](https://user-images.githubusercontent.com/3179271/164777213-a1293d7d-8f00-4799-81b7-07bea9adfd86.png)

