### PR TITLE
[Expert] Nature's Aura tweaks to better prepare the player for the threat the Masticator poses

### DIFF
--- a/config/ftbquests/quests/chapters/magic__adept.snbt
+++ b/config/ftbquests/quests/chapters/magic__adept.snbt
@@ -18,7 +18,7 @@
 				""
 				"Summoning the Masticator requires the Altar of Birthing as well as several other items. Look up the recipe for the Masticator Spawn egg in JEI to find them. "
 				""
-				"Be warned, its hunger is deep and summoning it will consume the Aura in the area. Allow it to drop too low and the consequences will be dire for the surrounding area."
+				"Be warned, its hunger is deep and summoning it will consume the Aura in the area. Allow it to drop too low and the consequences will be dire for life in the surrounding area."
 			]
 			dependencies: [
 				"583A58418CBF0606"

--- a/config/ftbquests/quests/chapters/magic__adept.snbt
+++ b/config/ftbquests/quests/chapters/magic__adept.snbt
@@ -10,7 +10,7 @@
 	quests: [
 		{
 			x: -2.0d
-			y: -2.5d
+			y: -1.5d
 			description: [
 				"Capable of grinding stone to dust in its mighty jaws, the Masticator’s scales were found to have great alchemical powers, specifically in creating magical flora to digest various objects and extract the latent energies within."
 				""
@@ -69,14 +69,14 @@
 		}
 		{
 			x: -2.0d
-			y: -4.5d
+			y: -3.5d
 			shape: "diamond"
 			description: [
 				"Journey to the depths of the Undergarden and seek out the catacombs where the ancients buried their revered dead. Be wary, as these tombs are well guarded. "
 				""
 				"While the art of making these automatons was lost long ago to the sands of time, not all knowledge of them is lost. There exist some forest creatures who remain quite adept at harvesting excess metal from them without harm to the automaton. "
 			]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["1684922D360579EA"]
 			id: "3244CF5322CDA8FA"
 			tasks: [{
 				id: "67D72ED6F85B74D2"
@@ -86,10 +86,10 @@
 		}
 		{
 			x: -2.5d
-			y: -4.0d
+			y: -3.0d
 			shape: "diamond"
 			description: ["The shadows deepen all around when in the presence of these mystical gems. "]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["1684922D360579EA"]
 			id: "70FE54E5B37720F8"
 			tasks: [{
 				id: "2EDC01F6C01A4342"
@@ -99,7 +99,7 @@
 		}
 		{
 			x: -1.5d
-			y: -4.0d
+			y: -3.0d
 			shape: "diamond"
 			description: [
 				"“It is wise to direct your anger towards problems, not people; to focus your energies on answers, not excuses.”"
@@ -107,8 +107,8 @@
 				"– Master Gyatso the Serene"
 			]
 			dependencies: [
-				"6A88DD23AB4B2551"
 				"2A45214DF4B8A3A0"
+				"1684922D360579EA"
 			]
 			id: "583A58418CBF0606"
 			tasks: [{
@@ -119,10 +119,10 @@
 		}
 		{
 			x: -2.0d
-			y: -3.5d
+			y: -2.5d
 			shape: "diamond"
 			description: ["A rare delicacy for beasts not of this plain. "]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["1684922D360579EA"]
 			id: "7D6DB53D88AA8955"
 			tasks: [{
 				id: "30B057E09BA7FEC1"
@@ -193,7 +193,7 @@
 		}
 		{
 			x: -1.0d
-			y: -4.5d
+			y: -3.5d
 			shape: "diamond"
 			description: [
 				"Komodo dragons may be found in many dry climates and “befriended” with suitably rotten meat. Their spit is prized by alchemists and naturalists alike. In the case of the former, as a reagent for purifying ore, and the latter for the deep emotions it evokes."
@@ -210,7 +210,7 @@
 		}
 		{
 			x: -2.0d
-			y: -1.5d
+			y: 0.0d
 			description: [
 				"Source and Aura, both facets of the same whole: Mana. With access to Generating Flora pure Mana may be extracted and used in a variety of new ways."
 				""
@@ -226,7 +226,7 @@
 		}
 		{
 			x: -2.0d
-			y: -0.5d
+			y: 1.0d
 			description: ["The neophyte believes runes are simply carved symbols; decorative and nothing more. But magical practitioners know the truth; they are carved purposely to channel magical energies to specific purposes. Doing so requires great effort of will. "]
 			dependencies: ["0E6B41A9E8802F67"]
 			id: "46993F7BA43BE3AB"
@@ -356,6 +356,7 @@
 		{
 			x: 2.0d
 			y: -3.0d
+			description: ["It hums subtly when held."]
 			dependencies: ["32D9D96C23106285"]
 			id: "0D8649291801C76C"
 			tasks: [{
@@ -423,7 +424,7 @@
 		}
 		{
 			x: -3.0d
-			y: 0.5d
+			y: 2.0d
 			description: [
 				"This world is filled with invisible beings. Watching. Waiting."
 				""
@@ -453,7 +454,7 @@
 		}
 		{
 			x: -3.5d
-			y: -1.5d
+			y: 0.0d
 			description: ["To properly summon the Wilden Chimera, one must offer tributes claimed from the bodies of each of the lesser Wilden that roam the lands. "]
 			dependencies: ["37E5C854B3C997E6"]
 			id: "638E2FA97CF961F7"
@@ -477,7 +478,7 @@
 		}
 		{
 			x: -4.0d
-			y: -0.5d
+			y: 1.0d
 			description: ["Place down the tablet and let it burn. Toss the remaining tributes atop the pyre and activate the ritual when ready. "]
 			dependencies: ["638E2FA97CF961F7"]
 			id: "54BD6A448EC80453"
@@ -489,7 +490,7 @@
 		}
 		{
 			x: -4.0d
-			y: -2.5d
+			y: -1.5d
 			description: [
 				"Flip a coin. "
 				""
@@ -516,10 +517,10 @@
 		}
 		{
 			x: -3.5d
-			y: -4.0d
+			y: -3.0d
 			shape: "diamond"
 			description: ["Though they themselves quite unaware of it, the coins traded by the denizens of Atum hold great arcane potential. Some have theorized that it may be due to a special alloying of nebu within the coins. "]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["5DBF0C080455A59F"]
 			id: "0140C94C9E0BE11B"
 			tasks: [{
 				id: "358386F4F0FC273F"
@@ -529,10 +530,10 @@
 		}
 		{
 			x: -4.5d
-			y: -4.0d
+			y: -3.0d
 			shape: "diamond"
 			description: ["Oft named Lucky Bees, Quartz bees were kept around the lab for one simple reason: Their crystalline growth tended to change colors when exposed to trace amounts of toxins in the air, allowing observant Alchemists to avoid disaster.  "]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["5DBF0C080455A59F"]
 			id: "749514BCD02A1A51"
 			tasks: [{
 				id: "4F21E8E2B24A5777"
@@ -542,10 +543,10 @@
 		}
 		{
 			x: -4.0d
-			y: -3.5d
+			y: -2.5d
 			shape: "diamond"
 			description: ["Many an early Alchemist met their end through a slip of the hand or a slight imperfection in their glassware. It’s no wonder, then, that they quickly developed tinctures to help improve their luck when dealing with dangerous substances. "]
-			dependencies: ["6A88DD23AB4B2551"]
+			dependencies: ["5DBF0C080455A59F"]
 			id: "14B74BACBD651D14"
 			tasks: [{
 				id: "5CE84C7DE08F8B26"
@@ -555,7 +556,7 @@
 		}
 		{
 			x: -4.5d
-			y: -1.5d
+			y: 0.0d
 			description: [
 				"Magic takes its toll, both mentally and physically. Many have succumbed to lesser trials, never even reaching this far. Will the Wilden Chimera prove too great a challenge?"
 				""
@@ -637,7 +638,7 @@
 		}
 		{
 			x: -3.0d
-			y: 1.5d
+			y: 3.0d
 			description: [
 				"“There was always something new to be seen in the unchanging night sky…”"
 				""
@@ -649,6 +650,64 @@
 				id: "652DE77D344E1B5F"
 				type: "item"
 				item: "astralsorcery:altar_attunement"
+			}]
+		}
+		{
+			title: "Aura Generation"
+			x: -2.0d
+			y: -4.5d
+			description: [
+				"The ancients knew to care for the natural resources at their disposal, using only what is needed and replenishing more than was taken. For every tree cut, two grown. "
+				""
+				"The Aura exuded by life needs similar care. When used in the Natural Arts, it must similarly be replenished. Failure to do will lead to catastrophic consequences."
+				""
+				"While many methods exist, The Shooting Mark and Herbivorous Absorber both offer paths to rapid Aura replenishment. Treat Nature well and she’ll respond in kind. Abuse her and face her wrath. "
+			]
+			dependencies: ["6A88DD23AB4B2551"]
+			id: "1684922D360579EA"
+			tasks: [{
+				id: "53DCB9AF9595A5D2"
+				type: "item"
+				title: "Aura Generation"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "naturesaura:flower_generator"
+								Count: 1b
+							}
+							{
+								id: "naturesaura:projectile_generator"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+		}
+		{
+			x: -4.0d
+			y: -4.5d
+			description: [
+				"The bees that inhabit these lands were long ago infused with powerful magics and though that magic has waned some without proper tending the thread remains in their descendants. With a bit of care, that deeper connection may be restored, allowing them to produce marvelous resources useful in both the Arcane and Technological arts. "
+				""
+				"Gather some bees and their nests to begin tending them. Through selective breeding and other techniques, more powerful bees may be produced. Their resources will be vital going forward. "
+			]
+			dependencies: ["6A88DD23AB4B2551"]
+			id: "5DBF0C080455A59F"
+			tasks: [{
+				id: "4024203A654C177D"
+				type: "item"
+				title: "Any Bee Nest"
+				item: {
+					id: "itemfilters:tag"
+					Count: 1b
+					tag: {
+						value: "forge:beehives/tier_0"
+					}
+				}
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/magic__adept.snbt
+++ b/config/ftbquests/quests/chapters/magic__adept.snbt
@@ -34,8 +34,8 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 1.5d
+			x: 1.5d
+			y: 3.0d
 			description: ["Exceptionally transformative and exceedingly dangerous, Hellfire has been used in the arcane arts since time immemorable. There is no safe way for mere humans to work with it directly, however, though the Spirits of the Otherworld seem to have no difficulties channeling it through a specially prepared forge. "]
 			dependencies: ["2B6914734BC1B9EA"]
 			id: "76E780FECC4F3BA8"
@@ -46,8 +46,8 @@
 			}]
 		}
 		{
-			x: 3.0d
-			y: 0.5d
+			x: 2.0d
+			y: 2.0d
 			description: [
 				"“Not all spirits come willingly. Some find this plane… distasteful. They may still be of use, however, bound into items of power that limit their contact with this place.”"
 				""
@@ -355,7 +355,7 @@
 		}
 		{
 			x: 2.0d
-			y: -3.0d
+			y: -2.5d
 			description: ["It hums subtly when held."]
 			dependencies: ["32D9D96C23106285"]
 			id: "0D8649291801C76C"
@@ -596,8 +596,8 @@
 			}]
 		}
 		{
-			x: 3.5d
-			y: 1.5d
+			x: 2.5d
+			y: 3.0d
 			description: [
 				"“Open your eyes and then open your eyes again.”"
 				""
@@ -621,7 +621,11 @@
 			x: 1.0d
 			y: -0.5d
 			shape: "diamond"
-			description: ["Effective as it may be some practitioners find the practice of sacrificing other beings distasteful. The Adept learns early on to give of their own blood as sacrifice, and to draw upon the earth for healing. "]
+			description: [
+				"Effective as it may be, some practitioners find the practice of sacrificing other beings distasteful."
+				""
+				"The Adept learns early on to give of their own blood as sacrifice, and to draw upon the earth for healing. "
+			]
 			dependencies: ["7BA120BEA495D354"]
 			id: "57FFFBB68F2655C1"
 			tasks: [{
@@ -659,7 +663,7 @@
 			description: [
 				"The ancients knew to care for the natural resources at their disposal, using only what is needed and replenishing more than was taken. For every tree cut, two grown. "
 				""
-				"The Aura exuded by life needs similar care. When used in the Natural Arts, it must similarly be replenished. Failure to do will lead to catastrophic consequences."
+				"The Aura exuded by life needs similar care. When used in the Natural Arts, it must similarly be replenished. Failure to do so will lead to catastrophic consequences."
 				""
 				"While many methods exist, The Shooting Mark and Herbivorous Absorber both offer paths to rapid Aura replenishment. Treat Nature well and she’ll respond in kind. Abuse her and face her wrath. "
 			]

--- a/config/ftbquests/quests/chapters/tools.snbt
+++ b/config/ftbquests/quests/chapters/tools.snbt
@@ -2935,9 +2935,15 @@
 				""
 				"With Shrink’s Personal Shrinking Device in hand, shrink to the tiniest of sizes and slip through cracks even a mouse would scoff at. "
 				""
-				"Sneak + Right Click to shrink yourself, or left click an entity to shrink it instead. Right click a shrunken entity to bottle it up and carry it with you. Keep a villager in your pocket for good luck!"
+				"● Right Click to open the GUI and select a size."
+				"● Sneak + Right Click to shrink yourself."
+				"● Left Click an entity to shrink it. "
+				"● Right Click a shrunken entity with a Glass Bottle to pick it up. "
+				""
+				"Keep a villager in your pocket for good luck!"
 			]
 			dependencies: ["00000000000003FF"]
+			min_width: 300
 			id: "2A74822BE970E9D4"
 			tasks: [{
 				id: "417D1AA02B005770"

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -525,6 +525,7 @@ const recipesToHide = [
             'naturesaura:death_ring',
             'naturesaura:ender_crate',
             'naturesaura:ender_access',
+            'naturesaura:gold_nether_brick',
 
             'pneumaticcraft:air_compressor',
             'pneumaticcraft:advanced_air_compressor',

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -362,6 +362,7 @@ const itemsToHide = [
     /emendatusenigmatica:\w+_brimstone_ore/,
     /emendatusenigmatica:\w+_soul_soil_ore/,
     /emendatusenigmatica:\w+_basalt_ore/,
+    /emendatusenigmatica:certus/,
     /tconstruct:copper_(ore|block|nugget)/,
     /tconstruct:cobalt_(ore|block|nugget)/,
     /titanium:\w+_gear/,
@@ -507,6 +508,8 @@ const recipesToHide = [
             'botania:blood_pendant',
             'botania:ender_dagger',
             'botania:brewery',
+            'botania:thorn_chakram',
+            'botania:flare_chakram',
 
             'mythicbotany:wither_aconite_floating',
             'mythicbotany:raindeletia_floating',

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -297,6 +297,8 @@ const itemsToHide = [
 
     'refinedstorage:silicon',
 
+    'shrink:shrink_ray',
+
     'simplefarming:apple_pie',
     'simplefarming:blueberry_pie',
 

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -200,7 +200,8 @@ onEvent('jei.information', (event) => {
                 'quark:indigo_crystal',
                 'quark:violet_crystal',
                 'quark:white_crystal',
-                'quark:black_crystal'],
+                'quark:black_crystal'
+            ],
             text: [
                 'Will grow up to four blocks tall if placed deep underground. Will emit particles while growing.',
                 ' ',
@@ -475,7 +476,9 @@ onEvent('jei.information', (event) => {
         },
         {
             items: ['naturesaura:break_prevention'],
-            text: [`When applied to a tool in an anvil, the tool will just stop working when durability runs out, instead of being destroyed.`]
+            text: [
+                `When applied to a tool in an anvil, the tool will just stop working when durability runs out, instead of being destroyed.`
+            ]
         },
         {
             items: ['ars_nouveau:belt_of_levitation'],
@@ -483,11 +486,23 @@ onEvent('jei.information', (event) => {
         },
         {
             items: ['create:chromatic_compound', 'create:refined_radiance'],
-            text: [`Chromatic Compound absorbs light when dropped in the world, transforming into Refined Radiance. Charges slowly from ambient light, faster by consuming nearby light emitting blocks, and instantly when dropped onto an active beacon.`]
+            text: [
+                `Chromatic Compound absorbs light when dropped in the world, transforming into Refined Radiance. Charges slowly from ambient light, faster by consuming nearby light emitting blocks, and instantly when dropped onto an active beacon.`
+            ]
         },
         {
             items: ['create:chromatic_compound', 'create:shadow_steel'],
-            text: [`Chromatic Compound absorbs darkness when dropped into the void, returning as Shadow Steel, floating back up out of the void shortly after falling into the depths.`]
+            text: [
+                `Chromatic Compound absorbs darkness when dropped into the void, returning as Shadow Steel, floating back up out of the void shortly after falling into the depths.`
+            ]
+        },
+        {
+            items: ['naturesaura:projectile_generator'],
+            text: [`Valid Projectiles:`, ``, `● Snowballs`, `● Eggs`, `● Arrows`, `● Fire Charges`, `● Spectral Arrows`]
+        },
+        {
+            items: ['naturesaura:projectile_generator'],
+            text: [`● Ender Pearls`, `● Llama Spit`, `● Bottles o' Enchanting`, `● Shulker Bullets`, `● Tridents`]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -266,6 +266,8 @@ onEvent('recipes', (event) => {
         { output: 'botania:blood_pendant', id: 'botania:blood_pendant' },
         { output: 'botania:ender_dagger', id: 'botania:ender_dagger' },
         { output: 'botania:brewery', id: 'botania:brewery' },
+        { output: 'botania:thorn_chakram', id: 'botania:thorn_chakram' },
+        { output: 'botania:flare_chakram', id: 'botania:flare_chakram' },
 
         { output: 'botania:gaia_pylon', id: 'mythicbotany:modified_gaia_pylon_with_alfsteel' },
         { output: 'mythicbotany:alfsteel_pylon', id: 'mythicbotany:alfsteel_pylon' },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -284,6 +284,7 @@ onEvent('recipes', (event) => {
         { output: 'naturesaura:death_ring', id: 'naturesaura:death_ring' },
         { output: 'naturesaura:ender_crate', id: 'naturesaura:ender_crate' },
         { output: 'naturesaura:ender_access', id: 'naturesaura:ender_access' },
+        { output: 'naturesaura:gold_nether_brick', id: 'naturesaura:gold_nether_brick' },
 
         { output: 'pneumaticcraft:air_compressor', id: 'pneumaticcraft:air_compressor' },
         { output: 'pneumaticcraft:advanced_air_compressor', id: 'pneumaticcraft:advanced_air_compressor' },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
@@ -83,22 +83,6 @@ onEvent('recipes', (event) => {
             id: 'astralsorcery:altar/altar_attunement'
         },
         {
-            output: Item.of('naturesaura:animal_spawner'),
-            pattern: ['_____', '_ABA_', '_CDE_', '_ABA_', '_____'],
-            key: {
-                A: { tag: 'resourcefulbees:resourceful_honeycomb_block' },
-                B: { item: 'ars_nouveau:summoning_crystal' },
-                C: { item: 'naturesaura:token_joy' },
-                D: { item: 'minecraft:spawner' },
-                E: { item: 'naturesaura:token_anger' }
-            },
-            altar_type: 0,
-            duration: 100,
-            starlight: 500,
-            effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
-            id: `${id_prefix}animal_spawner`
-        },
-        {
             output: Item.of('botania:runic_altar'),
             pattern: ['_____', '_AAA_', '_ABA_', '_CDC_', '_____'],
             key: {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -66,6 +66,14 @@ onEvent('recipes', (event) => {
             catalyst: 'architects_palette:moonstone',
             id: 'botania:mana_infusion/mana_pearl'
         },
+        {
+            input: 'ars_nouveau:marvelous_clay',
+            output: 'ars_nouveau:mythical_clay',
+            count: 1,
+            mana: 10000,
+            catalyst: 'architects_palette:sunstone',
+            id: 'ars_nouveau:mythical_clay'
+        },
 
         /// Patchouli Safe Removals
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -639,6 +639,12 @@ onEvent('recipes', (event) => {
             output: 'eidolon:unholy_effigy',
             count: 1,
             id: `${id_prefix}unholy_effigy`
+        },
+        {
+            inputs: ['minecraft:nether_bricks', 'naturesaura:gold_fiber', 'thermal:phytogro'],
+            output: 'naturesaura:gold_nether_brick',
+            count: 1,
+            id: `${id_prefix}gold_nether_brick`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
@@ -17,40 +17,8 @@ onEvent('recipes', (event) => {
                 empty_weight: 0,
                 rolls: 1
             },
-            consume_fluid: 1.0,
+            consume_fluid: 0.0,
             id: 'ars_nouveau:magic_clay'
-        },
-        {
-            inputs: [
-                { item: 'ars_nouveau:magic_clay', count: 2 },
-                { item: 'naturesaura:gold_powder', count: 1 },
-                { tag: 'forge:dusts/mana', count: 1 },
-                { tag: 'forge:dusts/lapis', count: 2 }
-            ],
-            fluid: { fluid: 'water' },
-            output: {
-                entries: [{ result: { item: 'ars_nouveau:marvelous_clay', count: 2 }, weight: 1 }],
-                empty_weight: 0,
-                rolls: 1
-            },
-            consume_fluid: 1.0,
-            id: 'ars_nouveau:marvelous_clay'
-        },
-        {
-            inputs: [
-                { item: 'ars_nouveau:marvelous_clay', count: 2 },
-                { tag: 'forge:dusts/emerald', count: 2 },
-                { tag: 'forge:dusts/mana', count: 1 },
-                { item: 'thermal:blitz_powder', count: 2 }
-            ],
-            fluid: { fluid: 'water' },
-            output: {
-                entries: [{ result: { item: 'ars_nouveau:mythical_clay', count: 2 }, weight: 1 }],
-                empty_weight: 0,
-                rolls: 1
-            },
-            consume_fluid: 1.0,
-            id: 'ars_nouveau:mythical_clay'
         },
         {
             inputs: [
@@ -66,33 +34,29 @@ onEvent('recipes', (event) => {
                 empty_weight: 0,
                 rolls: 1
             },
-            consume_fluid: 1.0,
+            consume_fluid: 0.0,
             id: 'meetyourfight:spectres_eye'
         },
         {
-            inputs: [
-                { item: 'kubejs:hot_compressed_iron_ingot', count: 1 }
-            ],
+            inputs: [{ item: 'kubejs:hot_compressed_iron_ingot', count: 1 }],
             fluid: { fluid: 'water' },
             output: {
                 entries: [{ result: { item: 'pneumaticcraft:ingot_iron_compressed', count: 1 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
             },
-            consume_fluid: 0.2,
+            consume_fluid: 0.0,
             id: 'enigmatica:expert/interactio/ingot_iron_compressed'
         },
         {
-            inputs: [
-                { item: 'kubejs:hot_compressed_iron_block', count: 1 }
-            ],
+            inputs: [{ item: 'kubejs:hot_compressed_iron_block', count: 1 }],
             fluid: { fluid: 'water' },
             output: {
                 entries: [{ result: { item: 'pneumaticcraft:compressed_iron_block', count: 1 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
             },
-            consume_fluid: 1.0,
+            consume_fluid: 0.0,
             id: 'enigmatica:expert/interactio/compressed_iron_block'
         }
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -72,8 +72,8 @@ onEvent('recipes', (event) => {
             input: 'minecraft:ender_pearl',
             output: { item: 'integrateddynamics:proto_chorus' },
             aura_type: 'naturesaura:nether',
-            aura: 135000,
-            time: 700,
+            aura: 5000,
+            time: 20,
             id: 'integrateddynamics:crafting/proto_chorus'
         },
         {
@@ -144,6 +144,38 @@ onEvent('recipes', (event) => {
             aura: 50000,
             time: 20,
             id: `${id_prefix}floral_fertilizer`
+        },
+        {
+            input: 'minecraft:slime_ball',
+            output: { item: 'tconstruct:ichor_slime_ball' },
+            aura_type: 'naturesaura:nether',
+            aura: 5000,
+            time: 20,
+            id: `${id_prefix}ichor_slime_ball`
+        },
+        {
+            input: 'minecraft:slime_ball',
+            output: { item: 'tconstruct:sky_slime_ball' },
+            aura_type: 'naturesaura:overworld',
+            aura: 5000,
+            time: 20,
+            id: `${id_prefix}sky_slime_ball`
+        },
+        {
+            input: 'tconstruct:earth_congealed_slime',
+            output: { item: 'tconstruct:ichor_congealed_slime' },
+            aura_type: 'naturesaura:nether',
+            aura: 5000 * 3,
+            time: 20 * 3,
+            id: `${id_prefix}ichor_congealed_slime`
+        },
+        {
+            input: 'tconstruct:earth_congealed_slime',
+            output: { item: 'tconstruct:sky_congealed_slime' },
+            aura_type: 'naturesaura:overworld',
+            aura: 5000 * 3,
+            time: 20 * 3,
+            id: `${id_prefix}sky_congealed_slime`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -176,6 +176,30 @@ onEvent('recipes', (event) => {
             aura: 5000 * 3,
             time: 20 * 3,
             id: `${id_prefix}sky_congealed_slime`
+        },
+        {
+            input: 'create:rose_quartz',
+            output: { item: 'create:polished_rose_quartz' },
+            aura_type: 'naturesaura:overworld',
+            aura: 5000,
+            time: 20,
+            id: `${id_prefix}polished_rose_quartz`
+        },
+        {
+            input: 'botania:vine_ball',
+            output: { item: 'botania:thorn_chakram', count: 2 },
+            aura_type: 'naturesaura:overworld',
+            aura: 135000,
+            time: 500,
+            id: `${id_prefix}thorn_chakram`
+        },
+        {
+            input: 'ars_nouveau:mana_bloom_crop',
+            output: { item: 'botania:overgrowth_seed' },
+            aura_type: 'naturesaura:overworld',
+            aura: 500000,
+            time: 1000,
+            id: `${id_prefix}overgrowth_seed`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -136,6 +136,14 @@ onEvent('recipes', (event) => {
             aura: 20000,
             time: 20,
             id: `${id_prefix}mana_powder`
+        },
+        {
+            input: 'thermal:phytogro',
+            output: { item: 'botania:fertilizer' },
+            aura_type: 'naturesaura:overworld',
+            aura: 50000,
+            time: 20,
+            id: `${id_prefix}floral_fertilizer`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -200,6 +200,22 @@ onEvent('recipes', (event) => {
             aura: 500000,
             time: 1000,
             id: `${id_prefix}overgrowth_seed`
+        },
+        {
+            input: 'ars_nouveau:mana_bloom_crop',
+            output: { item: 'botania:overgrowth_seed' },
+            aura_type: 'naturesaura:overworld',
+            aura: 500000,
+            time: 1000,
+            id: `${id_prefix}overgrowth_seed`
+        },
+        {
+            input: 'ars_nouveau:magic_clay',
+            output: { item: 'ars_nouveau:marvelous_clay' },
+            aura_type: 'naturesaura:overworld',
+            aura: 15000,
+            time: 20,
+            id: 'ars_nouveau:marvelous_clay'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -48,16 +48,16 @@ onEvent('recipes', (event) => {
             input: 'kubejs:firmament',
             output: { item: 'architects_palette:sunstone' },
             aura_type: 'naturesaura:overworld',
-            aura: 15000,
-            time: 80,
+            aura: 50000,
+            time: 20,
             id: `${id_prefix}sunstone`
         },
         {
             input: 'ars_nouveau:arcane_stone',
             output: { item: 'naturesaura:infused_stone' },
             aura_type: 'naturesaura:nether',
-            aura: 15000,
-            time: 40,
+            aura: 50000,
+            time: 20,
             id: 'naturesaura:altar/infused_stone'
         },
         {
@@ -119,6 +119,14 @@ onEvent('recipes', (event) => {
             aura: 15000,
             time: 80,
             id: `${id_prefix}duckweed`
+        },
+        {
+            input: 'ars_nouveau:arcane_stone',
+            output: { item: 'ars_nouveau:warding_stone' },
+            aura_type: 'naturesaura:overworld',
+            aura: 135000,
+            time: 40,
+            id: `${id_prefix}warding_stone`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -48,7 +48,7 @@ onEvent('recipes', (event) => {
             input: 'kubejs:firmament',
             output: { item: 'architects_palette:sunstone' },
             aura_type: 'naturesaura:overworld',
-            aura: 50000,
+            aura: 40000,
             time: 20,
             id: `${id_prefix}sunstone`
         },
@@ -56,7 +56,7 @@ onEvent('recipes', (event) => {
             input: 'ars_nouveau:arcane_stone',
             output: { item: 'naturesaura:infused_stone' },
             aura_type: 'naturesaura:nether',
-            aura: 50000,
+            aura: 40000,
             time: 20,
             id: 'naturesaura:altar/infused_stone'
         },
@@ -127,6 +127,15 @@ onEvent('recipes', (event) => {
             aura: 135000,
             time: 40,
             id: `${id_prefix}warding_stone`
+        },
+        {
+            input: '#forge:gems/mana',
+            output: { item: 'botania:mana_powder', count: 4 },
+            aura_type: 'naturesaura:overworld',
+            catalyst: { item: 'naturesaura:crushing_catalyst' },
+            aura: 20000,
+            time: 20,
+            id: `${id_prefix}mana_powder`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -482,6 +482,22 @@ onEvent('recipes', (event) => {
             output: 'botania:brewery',
             time: 4 * time_multiplier,
             id: `${id_prefix}brewery`
+        },
+        {
+            ingredients: [
+                'naturesaura:token_anger',
+                'naturesaura:token_joy',
+                'minecraft:spawner',
+                'ars_nouveau:summoning_crystal',
+                '#forge:storage_blocks/infused_iron',
+                '#forge:storage_blocks/infused_iron',
+                '#forge:storage_blocks/infused_iron',
+                '#forge:storage_blocks/infused_iron'
+            ],
+            sapling: 'quark:lavender_blossom_sapling',
+            output: 'naturesaura:animal_spawner',
+            time: 20 * time_multiplier,
+            id: `${id_prefix}animal_spawner`
         }
 
         /*

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -485,16 +485,16 @@ onEvent('recipes', (event) => {
         },
         {
             ingredients: [
+                'ars_nouveau:summoning_crystal',
+                Item.of('naturesaura:aura_cache', '{aura:400000}'),
                 'naturesaura:token_anger',
                 'naturesaura:token_joy',
-                'minecraft:spawner',
-                'ars_nouveau:summoning_crystal',
+                'botania:overgrowth_seed',
                 '#forge:storage_blocks/infused_iron',
-                '#forge:storage_blocks/infused_iron',
-                '#forge:storage_blocks/infused_iron',
+                'botania:overgrowth_seed',
                 '#forge:storage_blocks/infused_iron'
             ],
-            sapling: 'quark:lavender_blossom_sapling',
+            sapling: 'quark:blue_blossom_sapling',
             output: 'naturesaura:animal_spawner',
             time: 20 * time_multiplier,
             id: `${id_prefix}animal_spawner`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/bottler.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/bottler.js
@@ -59,6 +59,13 @@ onEvent('recipes', (event) => {
             output: 'gunswithoutroses:blaze_bullet',
             energy: 100,
             id: `${id_prefix}blaze_bullet`
+        },
+        {
+            input: 'botania:thorn_chakram',
+            fluid: Fluid.of('tconstruct:blazing_blood', 1000),
+            output: 'botania:flare_chakram',
+            energy: 15000,
+            id: `${id_prefix}flare_chakram`
         }
     ];
     recipes.forEach((recipe) => {


### PR DESCRIPTION
Move the Altar of Birthing recipe to the Ritual of the Forest
![image](https://user-images.githubusercontent.com/9543430/164953521-358fa665-6730-4107-a085-575ccf68bcb8.png)

Cost now includes a large quantity of sunmetal, driving up the aura cost to even make it. 

Cost of Sunstone increased, crafting time reduced, as the altar wasn't able to keep up with a pure daisy making living rock. 

Add recipe for warded stone to the altar, granting a solid material cost reduction at a steep aura cost
![image](https://user-images.githubusercontent.com/9543430/164878301-60be0bca-47f7-4e25-963b-d6b3a1651695.png)

Add recipe to quadruple mana dust
![image](https://user-images.githubusercontent.com/9543430/164878493-47ecb76c-9bf6-4fc2-ad39-5c529569f969.png)

Add recipe to generate floral fertilizer without dye. This cost about half as much aura as you get by using it to make flowers for an Herbivorous Absorber, so it does create a positive aura feedback.

![image](https://user-images.githubusercontent.com/9543430/164878818-aa355e2e-44a4-4049-b1eb-437f00e40e9a.png)

