### PR TITLE
[Expert] Update Mythic Botany Runes to assist with automation

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -321,11 +321,11 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                '#forge:ingots/refined_radiance',
+                '#forge:ingots/refined_glowstone',
                 '#botania:runes/fire',
                 '#botania:runes/summer',
                 '#botania:runes/wrath',
-                'architects_palette:sunstone'
+                'create:refined_radiance_casing'
             ],
             mana: 96000,
             output: 'mythicbotany:muspelheim_rune',
@@ -334,7 +334,7 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                'create:shadow_steel',
+                '#forge:ingots/arcane_gold',
                 '#botania:runes/earth',
                 '#botania:runes/winter',
                 '#botania:runes/sloth',
@@ -347,11 +347,11 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                '#forge:ingots/shadow_steel',
+                '#forge:ingots/refined_obsidian',
                 '#botania:runes/water',
                 '#botania:runes/winter',
                 '#botania:runes/wrath',
-                'architects_palette:moonstone'
+                'create:shadow_steel_casing'
             ],
             mana: 96000,
             output: 'mythicbotany:niflheim_rune',


### PR DESCRIPTION
The Create ingots previously used like to float, which poses a problem for people dropping them. Recipe works fine if right clicked, but I think people are more likely to drop than click.

Nidavellir
![image](https://user-images.githubusercontent.com/9543430/164914110-a42f2135-df6c-48c9-83fd-646e0a0b7018.png)

Helheim
![image](https://user-images.githubusercontent.com/9543430/164914121-36733d0d-d8ca-4c23-82ee-cbecc8d25eeb.png)

Muspelheim
![image](https://user-images.githubusercontent.com/9543430/164914134-57e09f93-ce2c-449b-b4f3-c9254cc3c702.png)
