### PR TITLE
Material Improvements

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -363,6 +363,7 @@ const itemsToHide = [
     /emendatusenigmatica:\w+_soul_soil_ore/,
     /emendatusenigmatica:\w+_basalt_ore/,
     /emendatusenigmatica:certus/,
+    /emendatusenigmatica:fluix/,
     /tconstruct:copper_(ore|block|nugget)/,
     /tconstruct:cobalt_(ore|block|nugget)/,
     /titanium:\w+_gear/,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -106,7 +106,9 @@ onEvent('recipes', (event) => {
 
         'eidolon:tallow',
         'eidolon:smelt_stone_brick',
-        'eidolon:lead_block',
+        'eidolon:decompress_lead_block',
+        'eidolon:lead_ingot',
+        'eidolon:decompress_lead_ingot',
 
         /emendatusenigmatica:dust_from_chunk/,
         'emendatusenigmatica:dust_from_ore/quartz',
@@ -276,12 +278,29 @@ onEvent('recipes', (event) => {
         /decorative_blocks:\w+_beam/,
         /decorative_blocks_abnormals:\w+_beam/,
         /mekanism:storage_blocks\/\w+/,
+        /mekanism:nuggets\/\w+/,
         /mekanism:processing\/\w+\/storage_blocks\/from_ingots/,
+        /mekanism:processing\/\w+\/ingot\/from_block/,
+        /mekanism:processing\/\w+\/ingot\/from_nuggets/,
+        /mekanism:processing\/\w+\/nugget\/from_ingot/,
         /thermal:storage\/\w+_block/,
+        /thermal:storage\/\w+_ingot_from_nuggets/,
+        /thermal:storage\/\w+_nugget_from_ingot/,
         /tconstruct:common\/materials\/\w+_block_from_ingots/,
+        /tconstruct:common\/materials\/\w+_ingot_from_block/,
+        /tconstruct:common\/materials\/\w+_ingot_from_nuggets/,
+        /tconstruct:common\/materials\/\w+_nugget_from_ingot/,
         /immersiveengineering:crafting\/ingot_\w+_to_storage_\w+/,
+        /immersiveengineering:crafting\/ingot_\w+_to_nugget_\w+/,
+        /immersiveengineering:crafting\/nugget_\w+_to_ingot_\w+/,
+        /immersiveengineering:crafting\/storage_\w+_to_ingot_\w+/,
         /create:crafting\/materials\/\w+_block_from_compacting/,
-        /occultism:crafting\/\w+_block/
+        /create:crafting\/materials\/\w+_ingot_from_compacting/,
+        /create:crafting\/materials\/\w+_ingot_from_decompacting/,
+        /create:crafting\/materials\/\w+_nugget_from_decompacting/,
+        /occultism:crafting\/\w+_block/,
+        /occultism:crafting\/\w+_nugget/,
+        /occultism:crafting\/\w+_ingot_from_nuggets/
     ];
 
     outputRemovals.forEach((removal) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -106,9 +106,11 @@ onEvent('recipes', (event) => {
 
         'eidolon:tallow',
         'eidolon:smelt_stone_brick',
+        'eidolon:lead_block',
 
         /emendatusenigmatica:dust_from_chunk/,
         'emendatusenigmatica:dust_from_ore/quartz',
+        'emendatusenigmatica:block_from_gem/arcane',
 
         'environmental:misc/cherries/cherry_pie',
         'environmental:misc/apple_pie',
@@ -160,6 +162,8 @@ onEvent('recipes', (event) => {
         'immersiveengineering:crusher/bone_meal',
         /immersiveengineering:crafting\/hammercrushing/,
         'immersivepetroleum:distillationtower/oilcracking',
+        'immersiveengineering:crafting/coal_coke_to_coke',
+        //'immersiveengineering:crafting/ingot_copper_to_storage_copper',
 
         'materialis:smeltery/melting/metal/starmetal/dust',
         /materialis:armor\/building\/exosuit/,
@@ -270,7 +274,14 @@ onEvent('recipes', (event) => {
         /atum:.*dye$/,
         /thermal:compat\/\w+\/\w+_ore/,
         /decorative_blocks:\w+_beam/,
-        /decorative_blocks_abnormals:\w+_beam/
+        /decorative_blocks_abnormals:\w+_beam/,
+        /mekanism:storage_blocks\/\w+/,
+        /mekanism:processing\/\w+\/storage_blocks\/from_ingots/,
+        /thermal:storage\/\w+_block/,
+        /tconstruct:common\/materials\/\w+_block_from_ingots/,
+        /immersiveengineering:crafting\/ingot_\w+_to_storage_\w+/,
+        /create:crafting\/materials\/\w+_block_from_compacting/,
+        /occultism:crafting\/\w+_block/
     ];
 
     outputRemovals.forEach((removal) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -106,6 +106,7 @@ onEvent('recipes', (event) => {
 
         'eidolon:tallow',
         'eidolon:smelt_stone_brick',
+        'eidolon:lead_block',
         'eidolon:decompress_lead_block',
         'eidolon:lead_ingot',
         'eidolon:decompress_lead_ingot',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -80,6 +80,7 @@ onEvent('recipes', (event) => {
         thermal_metal_melting(event, material, block, ingot, nugget, gear, rod, plate);
         thermal_gem_casting(event, material, gem, gear, rod, plate);
         thermal_gem_melting(event, material, block, gem, gear, rod, plate);
+        thermal_nugget_packing_unpacking(event, material, ingot, nugget);
 
         tconstruct_metal_casting(event, material, block, ingot, nugget, gear, rod, plate);
         tconstruct_gem_casting(event, material, block, gem, gear, rod, plate);
@@ -1311,6 +1312,35 @@ onEvent('recipes', (event) => {
                 .crucible(Fluid.of(`${modId}:molten_${material}`, recipe.amount), recipe.input)
                 .energy(recipe.energy)
                 .id(`enigmatica:base/thermal/crucible/${material}_${recipe.type}`);
+        })
+    }
+
+    function thermal_nugget_packing_unpacking(event, material, ingot, nugget) {
+        if (ingot == air || nugget == air){
+            return;
+        }
+        let recipes = [
+            {
+                inputs: [
+                    Item.of(nugget, 9),
+                    Ingredient.of('#thermal:crafting/dies/packing_3x3')
+                ],
+                outputs: [Item.of(ingot, 1)],
+                energy: 2400,
+                id: `thermal:machine/press/packing3x3/press_${material}_packing`
+            },
+            {
+                inputs: [
+                    Item.of(ingot, 1),
+                    Ingredient.of('#thermal:crafting/dies/unpacking')
+                ],
+                outputs: [Item.of(nugget, 9)],
+                energy: 2400,
+                id: `thermal:machine/press/unpacking/press_${material}_packing`
+            }
+        ]
+        recipes.forEach((recipe) => {
+            event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy).id(recipe.id);
         });
     }
 


### PR DESCRIPTION
Does a few things:

Declutter blocks/ingots/nuggets - ID Removes crafting table packing/unpacking recipes, leaving the EE recipes.

Remove Fluix materials from JEI - not dealing with the various fluid containers, as they're not being removed for other stuff.

Add Nugget <-> Ingot Packing/Unpacking recipes for the Thermal Multiservo Press. These were otherwise missing, so this adds them to the unification script.