### PR TITLE
Add Fly to Altar of Birthing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
@@ -398,6 +398,13 @@ onEvent('recipes', (event) => {
             aura: 50000,
             time: 60,
             id: `${id_prefix}clogged_bee`
+        },
+        {
+            inputs: ['naturesaura:birth_spirit', 'alexsmobs:maggot', 'farmersdelight:organic_compost'],
+            entity: 'alexsmobs:fly',
+            aura: 50000,
+            time: 60,
+            id: `${id_prefix}fly`
         }
     ];
 


### PR DESCRIPTION
With reduced spawn rates, they may be hard to come by. Adding them to the altar as an alternative.

![image](https://user-images.githubusercontent.com/9543430/165986578-3393eb75-d77f-4061-941d-9a6845aec584.png)
