### PR TITLE
[Expert] LP and Liquid Starlight Improvements Part Two

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -20,22 +20,6 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}oil`
         },
         {
-            output: '{FluidName:"astralsorcery:liquid_starlight",Amount:100}',
-            rarity: [
-                {
-                    whitelist: {},
-                    blacklist: { type: 'minecraft:worldgen/biome', values: nether_end_biomes },
-                    depth_min: 250,
-                    depth_max: 255,
-                    weight: 10
-                }
-            ],
-            pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens0' },
-            entity: 'minecraft:empty',
-            id: `${id_prefix}liquid_starlight`
-        },
-        {
             output: '{FluidName:"industrialforegoing:essence",Amount:5}',
             rarity: [
                 {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
@@ -19,7 +19,7 @@ onEvent('recipes', (event) => {
         {
             input: { item: 'astralsorcery:resonating_gem' },
             output: 'astralsorcery:liquid_starlight',
-            productionMultiplier: 0.75,
+            productionMultiplier: 10.0,
             shatterMultiplier: 100.0,
             color: -16734209,
             id: 'astralsorcery:lightwell/starlight_resonating_gem'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
@@ -19,7 +19,7 @@ onEvent('recipes', (event) => {
         {
             input: { item: 'astralsorcery:resonating_gem' },
             output: 'astralsorcery:liquid_starlight',
-            productionMultiplier: 10.0,
+            productionMultiplier: 50.0,
             shatterMultiplier: 100.0,
             color: -16734209,
             id: 'astralsorcery:lightwell/starlight_resonating_gem'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/lightwell.js
@@ -3,14 +3,26 @@ onEvent('recipes', (event) => {
         return;
     }
     const id_prefix = 'enigmatica:expert/astralsorcery/lightwell/';
+
+    // shatterMultiplier: higher means slower breaking
+    // productionMultiplier: higher means more product per cycle
+
     const recipes = [
         {
             input: { item: 'bloodmagic:slate_ampoule' },
             output: 'bloodmagic:life_essence_fluid',
-            productionMultiplier: 0.25,
-            shatterMultiplier: 20.0,
+            productionMultiplier: 100.0,
+            shatterMultiplier: 0.1,
             color: 16056324,
             id: `${id_prefix}life_essence`
+        },
+        {
+            input: { item: 'astralsorcery:resonating_gem' },
+            output: 'astralsorcery:liquid_starlight',
+            productionMultiplier: 0.75,
+            shatterMultiplier: 100.0,
+            color: -16734209,
+            id: 'astralsorcery:lightwell/starlight_resonating_gem'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -43,8 +43,8 @@ onEvent('recipes', (event) => {
             output: '{FluidName:"astralsorcery:liquid_starlight",Amount:1000}',
             rarity: [
                 {
-                    whitelist: {},
-                    blacklist: { type: 'minecraft:worldgen/biome', values: nether_end_biomes },
+                    whitelist: { type: 'minecraft:worldgen/biome', values: end_biomes },
+                    blacklist: {},
                     depth_min: 250,
                     depth_max: 255,
                     weight: 10

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -38,6 +38,22 @@ onEvent('recipes', (event) => {
             catalyst: { item: 'industrialforegoing:laser_lens14' },
             entity: 'minecraft:villager',
             id: `${id_prefix}life_essence_fluid`
+        },
+        {
+            output: '{FluidName:"astralsorcery:liquid_starlight",Amount:1000}',
+            rarity: [
+                {
+                    whitelist: {},
+                    blacklist: { type: 'minecraft:worldgen/biome', values: nether_end_biomes },
+                    depth_min: 250,
+                    depth_max: 255,
+                    weight: 10
+                }
+            ],
+            pointer: 0,
+            catalyst: { item: 'industrialforegoing:laser_lens0' },
+            entity: 'minecraft:empty',
+            id: `${id_prefix}liquid_starlight`
         }
     ];
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -202,20 +202,20 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}overgrowth_seed`
         },
         {
-            input: 'ars_nouveau:mana_bloom_crop',
-            output: { item: 'botania:overgrowth_seed' },
-            aura_type: 'naturesaura:overworld',
-            aura: 500000,
-            time: 1000,
-            id: `${id_prefix}overgrowth_seed`
-        },
-        {
             input: 'ars_nouveau:magic_clay',
             output: { item: 'ars_nouveau:marvelous_clay' },
             aura_type: 'naturesaura:overworld',
             aura: 15000,
             time: 20,
             id: 'ars_nouveau:marvelous_clay'
+        },
+        {
+            input: 'eidolon:soul_shard',
+            output: { item: 'bloodmagic:slate_ampoule' },
+            aura_type: 'naturesaura:nether',
+            aura: 15000,
+            time: 20,
+            id: `${id_prefix}slate_ampoule`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -15,6 +15,22 @@ onEvent('recipes', (event) => {
                     depth_min: 5,
                     depth_max: 10,
                     weight: 14
+                },
+                {
+                    output: '{FluidName:"astralsorcery:liquid_starlight",Amount:100}',
+                    rarity: [
+                        {
+                            whitelist: {},
+                            blacklist: { type: 'minecraft:worldgen/biome', values: nether_end_biomes },
+                            depth_min: 250,
+                            depth_max: 255,
+                            weight: 10
+                        }
+                    ],
+                    pointer: 0,
+                    catalyst: { item: 'industrialforegoing:laser_lens0' },
+                    entity: 'minecraft:empty',
+                    id: `${id_prefix}liquid_starlight`
                 }
             ],
             pointer: 0,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9543430/166514959-2adef9cf-a7a6-4740-9466-f3582d54cb83.png)

Adjust Slate to LP to be about 1.5 buckets per slate. This is a highly variable process, but should result in more than the base 500LP you get by popping these by hand. 

Greatly increases the duration that Resonating gems last in the lightwell, as well as boosting their output.  Given their cost to make, this makes them pretty beefy at making liquid starlight. 