### PR TITLE
Removed commas from apo spawner blacklist

### DIFF
--- a/config/apotheosis/spawner.cfg
+++ b/config/apotheosis/spawner.cfg
@@ -179,16 +179,15 @@ spawn_eggs {
         occultism:afrit
         atum:pharaoh
         occultism:marid
-        rftoolsdim:dimensional_blob_legendary
-        ars_nouveau:familiar_bookwyrm,
-        ars_nouveau:familiar_carbuncle,
-        ars_nouveau:familiar_drygmy,
-        ars_nouveau:familiar_jabberwog,
-        ars_nouveau:familiar_sylph,
-        ars_nouveau:familiar_wixie,
-        undergarden:masticator,
-        meetyourfight:swampjaw,
-        meetyourfight:bellringer,
+        ars_nouveau:familiar_bookwyrm
+        ars_nouveau:familiar_carbuncle
+        ars_nouveau:familiar_drygmy
+        ars_nouveau:familiar_jabberwog
+        ars_nouveau:familiar_sylph
+        ars_nouveau:familiar_wixie
+        undergarden:masticator
+        meetyourfight:swampjaw
+        meetyourfight:bellringer
         meetyourfight:dame_fortuna
      >
 }


### PR DESCRIPTION
also removed rftools dim blob cuz mod is long since yeeted
 every mob after the commas started are not currently blacklisted cuz .cfg apparently

fixes #4776 