### PR TITLE
A way to upgrade powah reactors

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -540,11 +540,52 @@ onEvent('recipes', (event) => {
             id: `powah:crafting/ender_gate_${tier}`
         });
     });
+    
+   powahTiers.forEach(function (this_tier, i) {
+      if (['starter', 'nitro'].includes(this_tier)) {
+          return;
+      }
+
+      function casingMaterial(tier) {
+        switch(tier) {
+          case 'basic': return {
+            tag: 'forge:storage_blocks/lead',
+            item: 'emendatusenigmatica:lead_block'};
+          case 'hardened': return {
+            tag: 'forge:storage_blocks/energized_steel',
+            item: 'powah:energized_steel_block'};
+          default: return {
+            tag: `forge:storage_blocks/${tier}`,
+            item: `powah:${tier}_crystal_block`};
+        }
+      }
+
+      let next_tier = powahTiers[i + 1];
+
+      recipes.push({
+        inputs: [
+          { item: `powah:reactor_${this_tier}`, count: 36 },
+          { item: `powah:energy_cell_${next_tier}`, count: 2, unstackable: true },
+          { item: `powah:thermo_generator_${next_tier}`, count: 3, unstackable: true },
+          { item: `powah:furnator_${next_tier}`, count: 1, unstackable: true },
+          { tag: casingMaterial(next_tier).tag, count: 6 }
+        ],
+        pressure: -0.75,
+        results: [
+          { item: `powah:reactor_${next_tier}`, count: 36 },
+          { item: `powah:energy_cell_${this_tier}`, count: 2 },
+          { item: `powah:thermo_generator_${this_tier}`, count: 3 },
+          { item: `powah:furnator_${this_tier}`, count: 1 },
+          { item: casingMaterial(this_tier).item, count: 6 }
+        ],
+        id: `${id_prefix}upgrade_${this_tier}_reactor_to_${next_tier}`
+      });
+    })
 
     recipes.forEach((recipe) => {
         let ingredients = [];
         recipe.inputs.forEach((input) => {
-            input.type = 'pneumaticcraft:stacked_item';
+            if (!input.unstackable) input.type = 'pneumaticcraft:stacked_item';
             ingredients.push(input);
         });
 


### PR DESCRIPTION
It would be neat if powah reactors were (losslessly) upgradable, on my expert multiplayer run players insisted rushing for a `niotic` tier reactor while still running only on refined fuel dynamos. (eventually they managed to even rush to `nitro`)

If the reactor tiers were upgradable (or dismantleable) it would not have been such a waste of the (non-powah) reactor ingredients since afterwards its still usable, but just a waste of materials. (basically the same sales pitch as if black hole)

My goal with this idea is to find a recipe type that makes sense & works, aka being able to take several ingredients and several outputs, originally i had the arc furnace in mind but of course those ingredients don't stack:

![Screen Shot 2022-05-05 at 20 54 24](https://user-images.githubusercontent.com/3179271/167020059-9ba8c5aa-d85c-4fe2-8c45-d154e6efd0fe.png)

```
    powahTiers.forEach(function (this_tier, i) {
      if (['starter', 'nitro'].includes(this_tier)) {
          return;
      }

      function casingMaterial(tier) {
        switch(tier) {
          case 'basic':    return '#forge:storage_blocks/lead';
          case 'hardened': return '#forge:storage_blocks/energized_steel';
          default:         return `#forge:storage_blocks/${tier}`;
        }
      }

      let next_tier = powahTiers[i + 1];

      data.recipes.push({
        input1: Item.of(`powah:reactor_${this_tier}`, 36),
        secondaries: [
          Item.of(`powah:energy_cell_${next_tier}`, 2).ignoreNBT(),
          Item.of(`powah:thermo_generator_${next_tier}`, 3).ignoreNBT(),
          Item.of(`powah:furnator_${next_tier}`).ignoreNBT(),
          Item.of(casingMaterial(next_tier), 6)
        ],
        outputs: [
          Item.of(`powah:reactor_${next_tier}`, 36),
          Item.of(`powah:energy_cell_${this_tier}`, 2),
          Item.of(`powah:thermo_generator_${this_tier}`, 3),
          Item.of(`powah:furnator_${this_tier}`),
          Item.of(casingMaterial(this_tier), 6)
        ],
        time: 100 * 36,
        energy: 51200 * 36,
        id: `${id_prefix}upgrade_${this_tier}_reactor_to_${next_tier}`
    })
```

Attempt two was using a pressure chamber (code for that is this pr), it appears to work as intended and just swaps out the blocks through suction:

![Screen Shot 2022-05-05 at 22 15 54](https://user-images.githubusercontent.com/3179271/167020084-24040658-780a-4653-8205-e02894275897.png)

The recipe does look a bit ugly and unclear in jei, gathering the items by hand is a bit of a pain, but it does however work:
![Screen Shot 2022-05-05 at 22 29 00](https://user-images.githubusercontent.com/3179271/167020256-8973713d-add1-4df0-8a32-b474b986b676.png)
(output barrel ^)

Alternative ways could be that the pnc chamber just straight up returns all the ingredients of the reactor (what about the nbt for the maxwell spirit?), or a sort of kubejs rightclick event listener on a set of mechanical crafters that just instantly puts items in their slots, honestly idk it sounds weird.

Of course the 36 blocks could also be upgraded one-by-one via sequenced assembly or other means, but that will require some calculations and balancing in regards to crystals needed for the next tier and the power usage the energizing orb will have taken.

I wouldn't advice merging this as-is, it appears that only one of each unstackable is consumed:
![Screen Shot 2022-05-05 at 22 34 14](https://user-images.githubusercontent.com/3179271/167021121-1fc8451a-0033-4b69-932c-67512fb2d702.png)
(notice the items in the hotbar after breaking the chamber ^)

Leaving this here as a place to discuss potential ways of dismantling or upgrading reactors in a fair way. ^-^ 🥔 


