### PR TITLE
Add `blazing blood` to the `fluid laser`

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -54,6 +54,23 @@ onEvent('recipes', (event) => {
             catalyst: { item: 'industrialforegoing:laser_lens0' },
             entity: 'minecraft:empty',
             id: `${id_prefix}liquid_starlight`
+        },
+        {
+            output: '{FluidName:"tconstruct:blazing_blood",Amount:1000}',
+            rarity: [
+                {
+                    whitelist: { type: 'minecraft:worldgen/biome', values: nether_biomes },
+                    blacklist: {},
+                    depth_min: 0,
+                    depth_max: 256,
+                    weight: 1
+                }
+            ],
+            pointer: 0,
+            catalyst: { item: 'industrialforegoing:laser_lens4' },
+            entity: 'minecraft:blaze',
+            type: 'industrialforegoing:laser_drill_fluid',
+            id: `${id_prefix}blazing_blood`
         }
     ];
     recipes.forEach((recipe) => {


### PR DESCRIPTION
Expert mode is rather heavy on blazing blood, it would be neat if it was obtainable without large quanties of blaze entities:
![2022-05-07_20 59 50](https://user-images.githubusercontent.com/3179271/167268281-35c83a7e-1222-4de7-aad3-5c421dbc5720.png)

While of course many expert recipes require large amounts of drops an thus large mob spawner setups with e.g. drygmys or looting blazing blood can only be obtained from melting either live blazes or their heads, both of those require entities.

This pull request merely allows you to use a fluid laser with a yellow lens over a single blaze to gain blazing blood.

(ps, this was edited online on github and was not yet tested/confirmed to work ingame, but it felt better than a suggestion)
