### PR TITLE
Kubejs laser lens constants to assist in maintaining

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -844,3 +844,24 @@ const craftedBees = [
     'electrum',
     'enderium'
 ];
+
+const industrialforegoing = {
+  laser_lens: {
+    white:      'industrialforegoing:laser_lens0',
+    orange:     'industrialforegoing:laser_lens1',
+    magenta:    'industrialforegoing:laser_lens2',
+    light_blue: 'industrialforegoing:laser_lens3',
+    yellow:     'industrialforegoing:laser_lens4',
+    lime:       'industrialforegoing:laser_lens5',
+    pink:       'industrialforegoing:laser_lens6',
+    gray:       'industrialforegoing:laser_lens7',
+    light_gray: 'industrialforegoing:laser_lens8',
+    cyan:       'industrialforegoing:laser_lens9',
+    purple:     'industrialforegoing:laser_lens10',
+    blue:       'industrialforegoing:laser_lens11',
+    brown:      'industrialforegoing:laser_lens12',
+    green:      'industrialforegoing:laser_lens13',
+    red:        'industrialforegoing:laser_lens14',
+    black:      'industrialforegoing:laser_lens15'
+  }
+};

--- a/kubejs/client_scripts/ponder/tech/industrialforegoing/laser_drill.js
+++ b/kubejs/client_scripts/ponder/tech/industrialforegoing/laser_drill.js
@@ -18,23 +18,23 @@ onEvent('ponder.registry', (event) => {
             'industrialforegoing:ore_laser_base',
             'industrialforegoing:fluid_laser_base',
             'industrialforegoing:laser_drill',
-            industrialforegoing.laser_lens.white,
-            industrialforegoing.laser_lens.orange,
-            industrialforegoing.laser_lens.orange,
-            industrialforegoing.laser_lens.magenta,
-            industrialforegoing.laser_lens.light_blue,
-            industrialforegoing.laser_lens.yellow,
-            industrialforegoing.laser_lens.lime,
-            industrialforegoing.laser_lens.pink,
-            industrialforegoing.laser_lens.gray,
-            industrialforegoing.laser_lens.light_gray,
-            industrialforegoing.laser_lens.cyan,
-            industrialforegoing.laser_lens.purple,
-            industrialforegoing.laser_lens.blue,
-            industrialforegoing.laser_lens.brown,
-            industrialforegoing.laser_lens.green,
-            industrialforegoing.laser_lens.red,
-            industrialforegoing.laser_lens.black,
+            'industrialforegoing:laser_lens0',
+            'industrialforegoing:laser_lens1',
+            'industrialforegoing:laser_lens1',
+            'industrialforegoing:laser_lens2',
+            'industrialforegoing:laser_lens3',
+            'industrialforegoing:laser_lens4',
+            'industrialforegoing:laser_lens5',
+            'industrialforegoing:laser_lens6',
+            'industrialforegoing:laser_lens7',
+            'industrialforegoing:laser_lens8',
+            'industrialforegoing:laser_lens9',
+            'industrialforegoing:laser_lens10',
+            'industrialforegoing:laser_lens11',
+            'industrialforegoing:laser_lens12',
+            'industrialforegoing:laser_lens13',
+            'industrialforegoing:laser_lens14',
+            'industrialforegoing:laser_lens15',
             'industrialforegoing:ether_gas_bucket'
         ])
         //.tag('enigmatica:industrial_foregoing')
@@ -392,7 +392,7 @@ onEvent('ponder.registry', (event) => {
                     .showControls(
                         new PonderInput([3.5, 4, 3.5], PonderPointing.DOWN)
                             .showing(PonderIcons.I_ADD)
-                            .withItem(`industrialforegoing:laser_lens1`),
+                            .withItem(industrialforegoing.laser_lens.orange),
                         30
                     );
 
@@ -512,7 +512,7 @@ onEvent('ponder.registry', (event) => {
                     .showControls(
                         new PonderInput([3.5, 7, 3.5], PonderPointing.DOWN)
                             .showing(PonderIcons.I_ADD)
-                            .withItem(`industrialforegoing:laser_lens10`),
+                            .withItem(industrialforegoing.laser_lens.purple),
                         60
                     );
 

--- a/kubejs/client_scripts/ponder/tech/industrialforegoing/laser_drill.js
+++ b/kubejs/client_scripts/ponder/tech/industrialforegoing/laser_drill.js
@@ -18,23 +18,23 @@ onEvent('ponder.registry', (event) => {
             'industrialforegoing:ore_laser_base',
             'industrialforegoing:fluid_laser_base',
             'industrialforegoing:laser_drill',
-            'industrialforegoing:laser_lens0',
-            'industrialforegoing:laser_lens1',
-            'industrialforegoing:laser_lens1',
-            'industrialforegoing:laser_lens2',
-            'industrialforegoing:laser_lens3',
-            'industrialforegoing:laser_lens4',
-            'industrialforegoing:laser_lens5',
-            'industrialforegoing:laser_lens6',
-            'industrialforegoing:laser_lens7',
-            'industrialforegoing:laser_lens8',
-            'industrialforegoing:laser_lens9',
-            'industrialforegoing:laser_lens10',
-            'industrialforegoing:laser_lens11',
-            'industrialforegoing:laser_lens12',
-            'industrialforegoing:laser_lens13',
-            'industrialforegoing:laser_lens14',
-            'industrialforegoing:laser_lens15',
+            industrialforegoing.laser_lens.white,
+            industrialforegoing.laser_lens.orange,
+            industrialforegoing.laser_lens.orange,
+            industrialforegoing.laser_lens.magenta,
+            industrialforegoing.laser_lens.light_blue,
+            industrialforegoing.laser_lens.yellow,
+            industrialforegoing.laser_lens.lime,
+            industrialforegoing.laser_lens.pink,
+            industrialforegoing.laser_lens.gray,
+            industrialforegoing.laser_lens.light_gray,
+            industrialforegoing.laser_lens.cyan,
+            industrialforegoing.laser_lens.purple,
+            industrialforegoing.laser_lens.blue,
+            industrialforegoing.laser_lens.brown,
+            industrialforegoing.laser_lens.green,
+            industrialforegoing.laser_lens.red,
+            industrialforegoing.laser_lens.black,
             'industrialforegoing:ether_gas_bucket'
         ])
         //.tag('enigmatica:industrial_foregoing')
@@ -245,7 +245,7 @@ onEvent('ponder.registry', (event) => {
                     .showControls(
                         new PonderInput([3.5, 4, 3.5], PonderPointing.DOWN)
                             .rightClick()
-                            .withItem(`industrialforegoing:laser_lens5`),
+                            .withItem(industrialforegoing.laser_lens.lime),
                         20
                     );
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -15,7 +15,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens15' },
+            catalyst: { item: industrialforegoing.laser_lens.black },
             entity: 'minecraft:empty',
             id: `${id_prefix}oil`
         },
@@ -31,7 +31,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens13' },
+            catalyst: { item: industrialforegoing.laser_lens.green },
             entity: 'minecraft:empty',
             id: `${id_prefix}essence`
         },
@@ -47,7 +47,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens4' },
+            catalyst: { item: industrialforegoing.laser_lens.yellow },
             entity: 'minecraft:empty',
             id: `${id_prefix}honey`
         },
@@ -63,7 +63,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens6' },
+            catalyst: { item: industrialforegoing.laser_lens.pink },
             entity: 'botania:pink_wither',
             id: `${id_prefix}pink_slime`
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
@@ -41,7 +41,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens8'
+                item: industrialforegoing.laser_lens.light_gray
             }
         },
         {
@@ -65,7 +65,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens2'
+                item: industrialforegoing.laser_lens.magenta
             }
         },
         {
@@ -89,7 +89,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens15'
+                item: industrialforegoing.laser_lens.black
             }
         },
         {
@@ -113,7 +113,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens7'
+                item: industrialforegoing.laser_lens.gray
             }
         },
         {
@@ -144,7 +144,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens0'
+                item: industrialforegoing.laser_lens.white
             }
         },
         {
@@ -168,7 +168,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens0'
+                item: industrialforegoing.laser_lens.white
             }
         },
         {
@@ -192,7 +192,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens15'
+                item: industrialforegoing.laser_lens.black
             }
         },
         {
@@ -216,7 +216,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens1'
+                item: industrialforegoing.laser_lens.orange
             }
         },
         {
@@ -240,7 +240,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens3'
+                item: industrialforegoing.laser_lens.light_blue
             }
         },
         {
@@ -264,7 +264,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens6'
+                item: industrialforegoing.laser_lens.pink
             }
         },
         {
@@ -288,7 +288,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens11'
+                item: industrialforegoing.laser_lens.blue
             }
         },
         {
@@ -312,7 +312,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens10'
+                item: industrialforegoing.laser_lens.purple
             }
         },
         {
@@ -336,7 +336,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens12'
+                item: industrialforegoing.laser_lens.brown
             }
         },
         {
@@ -360,7 +360,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens9'
+                item: industrialforegoing.laser_lens.cyan
             }
         },
         {
@@ -384,7 +384,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens12'
+                item: industrialforegoing.laser_lens.brown
             }
         },
         {
@@ -408,7 +408,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens0'
+                item: industrialforegoing.laser_lens.white
             }
         },
         {
@@ -432,7 +432,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens11'
+                item: industrialforegoing.laser_lens.blue
             }
         },
         {
@@ -456,7 +456,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens14'
+                item: industrialforegoing.laser_lens.red
             }
         },
         {
@@ -480,7 +480,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens8'
+                item: industrialforegoing.laser_lens.light_gray
             }
         },
         {
@@ -504,7 +504,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens4'
+                item: industrialforegoing.laser_lens.yellow
             }
         },
         {
@@ -528,7 +528,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens7'
+                item: industrialforegoing.laser_lens.gray
             }
         },
         {
@@ -552,7 +552,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens5'
+                item: industrialforegoing.laser_lens.lime
             }
         },
         {
@@ -586,7 +586,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens13'
+                item: industrialforegoing.laser_lens.green
             }
         },
         {
@@ -610,7 +610,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens4'
+                item: industrialforegoing.laser_lens.yellow
             }
         },
         {
@@ -651,7 +651,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens4'
+                item: industrialforegoing.laser_lens.yellow
             }
         },
         {
@@ -675,7 +675,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens7'
+                item: industrialforegoing.laser_lens.gray
             }
         },
         {
@@ -699,7 +699,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens8'
+                item: industrialforegoing.laser_lens.light_gray
             }
         },
         {
@@ -716,7 +716,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens12'
+                item: industrialforegoing.laser_lens.brown
             }
         },
         {
@@ -733,7 +733,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens12'
+                item: industrialforegoing.laser_lens.brown
             }
         },
         {
@@ -750,7 +750,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens9'
+                item: industrialforegoing.laser_lens.cyan
             }
         },
         {
@@ -767,7 +767,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens12'
+                item: industrialforegoing.laser_lens.brown
             }
         },
         {
@@ -784,7 +784,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens1'
+                item: industrialforegoing.laser_lens.orange
             }
         },
         {
@@ -801,7 +801,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens4'
+                item: industrialforegoing.laser_lens.yellow
             }
         },
         {
@@ -825,7 +825,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             catalyst: {
-                item: 'industrialforegoing:laser_lens3'
+                item: industrialforegoing.laser_lens.light_blue
             }
         }
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/industrialforegoing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/industrialforegoing.js
@@ -1,0 +1,22 @@
+//priority: 1000
+
+const industrialforegoing = {
+  laser_lens: {
+    white:      'industrialforegoing:laser_lens0',
+    orange:     'industrialforegoing:laser_lens1',
+    magenta:    'industrialforegoing:laser_lens2',
+    light_blue: 'industrialforegoing:laser_lens3',
+    yellow:     'industrialforegoing:laser_lens4',
+    lime:       'industrialforegoing:laser_lens5',
+    pink:       'industrialforegoing:laser_lens6',
+    gray:       'industrialforegoing:laser_lens7',
+    light_gray: 'industrialforegoing:laser_lens8',
+    cyan:       'industrialforegoing:laser_lens9',
+    purple:     'industrialforegoing:laser_lens10',
+    blue:       'industrialforegoing:laser_lens11',
+    brown:      'industrialforegoing:laser_lens12',
+    green:      'industrialforegoing:laser_lens13',
+    red:        'industrialforegoing:laser_lens14',
+    black:      'industrialforegoing:laser_lens15'
+  }
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -341,7 +341,7 @@ onEvent('recipes', (event) => {
                 C: 'mekanism:hdpe_sheet',
                 D: 'thermal:charge_bench',
                 E: 'rftoolsbase:infused_diamond',
-                F: 'industrialforegoing:laser_lens2',
+                F: industrialforegoing.laser_lens.magenta,
                 G: 'thermal:upgrade_augment_2',
                 H: Item.of('immersiveengineering:wooden_grip').ignoreNBT()
             },
@@ -356,7 +356,7 @@ onEvent('recipes', (event) => {
                 C: 'mekanism:hdpe_sheet',
                 D: 'thermal:charge_bench',
                 E: 'rftoolsbase:infused_diamond',
-                F: 'industrialforegoing:laser_lens6',
+                F: industrialforegoing.laser_lens.pink,
                 G: 'thermal:upgrade_augment_2',
                 H: Item.of('immersiveengineering:wooden_grip').ignoreNBT()
             },
@@ -371,7 +371,7 @@ onEvent('recipes', (event) => {
                 C: 'mekanism:hdpe_sheet',
                 D: 'thermal:charge_bench',
                 E: 'rftoolsbase:infused_diamond',
-                F: 'industrialforegoing:laser_lens3',
+                F: industrialforegoing.laser_lens.light_blue,
                 G: 'thermal:upgrade_augment_2',
                 H: Item.of('immersiveengineering:wooden_grip').ignoreNBT()
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -55,7 +55,7 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 'rftoolsutility:matter_receiver',
-                'industrialforegoing:laser_lens14',
+                industrialforegoing.laser_lens.red,
                 '#industrialforegoing:machine_frame/advanced',
                 'minecraft:spawner',
                 'minecraft:spawner'
@@ -71,7 +71,7 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 'rftoolsutility:matter_transmitter',
-                'industrialforegoing:laser_lens4',
+                industrialforegoing.laser_lens.yellow,
                 '#industrialforegoing:machine_frame/simple',
                 '#forge:gears/lumium',
                 '#forge:gears/lumium'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -67,7 +67,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens4' },
+            catalyst: { item: industrialforegoing.laser_lens.orange },
             entity: 'minecraft:blaze',
             type: 'industrialforegoing:laser_drill_fluid',
             id: `${id_prefix}blazing_blood`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -18,7 +18,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens12' },
+            catalyst: { item: industrialforegoing.laser_lens.brown },
             entity: 'minecraft:cow',
             type: 'industrialforegoing:laser_drill_fluid',
             id: `${id_prefix}liquid_meat`
@@ -35,7 +35,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens14' },
+            catalyst: { item: industrialforegoing.laser_lens.red },
             entity: 'minecraft:villager',
             id: `${id_prefix}life_essence_fluid`
         },
@@ -51,7 +51,7 @@ onEvent('recipes', (event) => {
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens0' },
+            catalyst: { item: industrialforegoing.laser_lens.white },
             entity: 'minecraft:empty',
             id: `${id_prefix}liquid_starlight`
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
@@ -383,7 +383,7 @@ onEvent('recipes', (event) => {
                 A: '#mekanism:alloys/infused',
                 B: 'mekanismgenerators:laser_focus_matrix',
                 C: 'mekanism:basic_induction_cell',
-                D: 'industrialforegoing:laser_lens14'
+                D: industrialforegoing.laser_lens.red
             },
             id: 'mekanism:laser_amplifier'
         },
@@ -392,7 +392,7 @@ onEvent('recipes', (event) => {
             pattern: [' B ', 'BAB', ' B '],
             key: {
                 A: 'mekanismgenerators:reactor_glass',
-                B: 'industrialforegoing:laser_lens14'
+                B: industrialforegoing.laser_lens.red
             },
             id: 'mekanismgenerators:laser_focus_matrix'
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -442,7 +442,7 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                { item: 'industrialforegoing:laser_lens10', count: 1 },
+                { item: industrialforegoing.laser_lens.purple, count: 1 },
                 { item: 'industrialforegoing:fluid_laser_base', count: 1 },
                 { item: 'industrialforegoing:laser_drill', count: 4 },
                 { item: 'industrialforegoing:speed_addon_2', count: 4 },

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -28,13 +28,13 @@ onEvent('recipes', (event) => {
                         }
                     ],
                     pointer: 0,
-                    catalyst: { item: 'industrialforegoing:laser_lens0' },
+                    catalyst: { item: industrialforegoing.laser_lens.white },
                     entity: 'minecraft:empty',
                     id: `${id_prefix}liquid_starlight`
                 }
             ],
             pointer: 0,
-            catalyst: { item: 'industrialforegoing:laser_lens14' },
+            catalyst: { item: industrialforegoing.laser_lens.red },
             entity: 'minecraft:villager',
             id: `${id_prefix}life_essence_fluid`
         }


### PR DESCRIPTION
> In the same spirit as #3044, basically intended to make industrial foregoing recipes in kubejs easier to maintain.

For my other recent pull request i had to look up [which color id related to orange](https://github.com/EnigmaticaModpacks/Enigmatica6/pull/4791/files), alternatively you could just memorize the color order, but that's not on my todo list atm.

So i coined a nested constant, doesn't really follow the naming convention of the other consts, but it does look better where it ends up being used. (and isn't foreached over, it just acts as a glorified enum)

Just like the other pr this hasn't been verified yet to be errorless since i have no development branch testing environment setup for e6, but at least vscode didn't complain about anything.

> Draft mode in case someone wishes to chance the naming convention used for this new laser lens constant.