### PR TITLE
[Expert] Alterations to Occultism Ritual outputs

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
@@ -123,6 +123,11 @@ onEvent('recipes', (event) => {
             filter: { mod: 'littlelogistics' },
             toReplace: '#forge:stone',
             replaceWith: 'minecraft:gray_concrete'
+        },
+        {
+            filter: { mod: 'modularrouters' },
+            toReplace: 'minecraft:ender_pearl',
+            replaceWith: 'botania:corporea_spark'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -2522,6 +2522,22 @@ onEvent('recipes', (event) => {
             reagent: Item.of('immersiveengineering:graphite_electrode', '{graphDmg:0}'),
             output: Item.of('immersiveengineering:graphite_electrode', '{graphDmg:0,Unbreakable:1}'),
             id: `${id_prefix}unbreakable_graphite_electrode`
+        },
+        {
+            inputs: [
+                'botania:pixie_dust',
+                'integratedterminals:chorus_glass',
+                'botania:pixie_dust',
+                'naturesaura:token_fear',
+                '#botania:runes/mana',
+                'botania:pixie_dust',
+                'integratedterminals:chorus_glass',
+                'botania:pixie_dust'
+            ],
+            reagent: '#forge:gems/mana_diamond',
+            sourceCost: 5000,
+            output: 'integrateddynamics:logic_director',
+            id: `${id_prefix}logic_director`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enderstorage/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enderstorage/shaped.js
@@ -6,37 +6,38 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             output: 'enderstorage:ender_pouch',
-            pattern: ['ABA', 'CEC', 'ADA'],
+            pattern: ['ABA', 'CDC', 'ECE'],
             key: {
-                A: { tag: 'forge:leather' },
+                A: { item: 'ars_nouveau:end_fiber' },
                 B: { tag: 'forge:wool' },
-                C: { tag: 'forge:inlays/arcane_gold' },
-                D: { item: 'botania:corporea_spark' },
-                E: { item: 'occultism:satchel' }
+                C: { item: 'alexsmobs:kangaroo_hide' },
+                D: { item: 'kubejs:dimensional_storage_crystal' },
+                E: { tag: 'forge:inlays/arcane_gold' }
             },
             id: 'enderstorage:ender_pouch'
         },
         {
             output: 'enderstorage:ender_chest',
-            pattern: ['ABA', 'CEC', 'ADA'],
+            pattern: ['ABA', 'CDC', 'ECE'],
             key: {
-                A: { tag: 'forge:plates/lumium' },
+                A: { item: 'ars_nouveau:end_fiber' },
                 B: { tag: 'forge:wool' },
-                C: { tag: 'forge:storage_blocks/hepatizon' },
-                D: { item: 'botania:corporea_spark' },
-                E: { item: 'occultism:satchel' }
+                C: { item: 'create:shadow_steel_casing' },
+                D: { item: 'kubejs:dimensional_storage_crystal' },
+                E: { tag: 'forge:plates/lumium' }
             },
             id: 'enderstorage:ender_chest'
         },
         {
             output: 'enderstorage:ender_tank',
-            pattern: ['ABA', 'CEC', 'ADA'],
+            pattern: ['ABA', 'FDF', 'ECE'],
             key: {
-                A: { tag: 'forge:rods/lumium' },
+                A: { item: 'ars_nouveau:end_fiber' },
                 B: { tag: 'forge:wool' },
-                C: { tag: 'thermal:glass/hardened' },
-                D: { item: 'botania:corporea_spark' },
-                E: { item: 'occultism:satchel' }
+                C: { item: 'create:shadow_steel_casing' },
+                D: { item: 'kubejs:dimensional_storage_crystal' },
+                E: { tag: 'forge:rods/lumium' },
+                F: { item: 'integratedterminals:chorus_glass' }
             },
             id: 'enderstorage:ender_tank'
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -494,7 +494,16 @@ onEvent('recipes', (event) => {
             id: 'mekanism:tier_installer/ultimate'
         },
         {
-            inputs: ['sophisticatedbackpacks:upgrade_base', 'occultism:satchel'],
+            inputs: [
+                'ars_nouveau:end_fiber',
+                'sophisticatedbackpacks:upgrade_base',
+                'ars_nouveau:end_fiber',
+                'create:shadow_steel_casing',
+                'create:shadow_steel_casing',
+                'ars_nouveau:end_fiber',
+                'kubejs:dimensional_storage_crystal',
+                'ars_nouveau:end_fiber'
+            ],
             inputFluid: 'kubejs:pink_ender_slime',
             inputFluidAmount: 250,
             processingTime: 100,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/modularrouters/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/modularrouters/shapeless.js
@@ -5,13 +5,20 @@ onEvent('recipes', (event) => {
     const id_prefix = 'enigmatica:expert/modularrouters/shapeless/';
     const recipes = [
         {
-            output: Item.of('2x modularrouters:sender_module_3'),
+            output: Item.of('modularrouters:sender_module_3'),
+            inputs: [Item.of('modularrouters:sender_module_2').ignoreNBT(), 'integrateddynamics:logic_director'],
+            id: 'modularrouters:sender_module_3'
+        },
+        {
+            output: Item.of('4x modularrouters:sender_module_3'),
             inputs: [
                 Item.of('modularrouters:sender_module_2').ignoreNBT(),
                 Item.of('modularrouters:sender_module_2').ignoreNBT(),
-                Item.of('occultism:satchel').ignoreNBT()
+                Item.of('modularrouters:sender_module_2').ignoreNBT(),
+                Item.of('modularrouters:sender_module_2').ignoreNBT(),
+                'integrateddynamics:logic_director'
             ],
-            id: 'modularrouters:sender_module_3'
+            id: `${id_prefix}sender_module_3_alt`
         },
         {
             output: Item.of('modularrouters:stack_upgrade'),
@@ -22,7 +29,7 @@ onEvent('recipes', (event) => {
                 'tconstruct:sky_slime_crystal',
                 'tconstruct:sky_slime_crystal'
             ],
-            id: 'modularrouters:stack_upgrade'
+            id: `'modularrouters:stack_upgrade'`
         },
         {
             output: 'modularrouters:flinger_module',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/modularrouters/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/modularrouters/shapeless.js
@@ -29,7 +29,7 @@ onEvent('recipes', (event) => {
                 'tconstruct:sky_slime_crystal',
                 'tconstruct:sky_slime_crystal'
             ],
-            id: `'modularrouters:stack_upgrade'`
+            id: 'modularrouters:stack_upgrade'
         },
         {
             output: 'modularrouters:flinger_module',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -1223,7 +1223,7 @@ onEvent('recipes', (event) => {
         },
         {
             ritual_type: 'occultism:craft',
-            activation_item: 'occultism:satchel',
+            activation_item: 'kubejs:dimensional_storage_crystal',
             pentacle_id: 'occultism:craft_djinni',
             duration: 100,
             entity_to_sacrifice: {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -696,7 +696,7 @@ onEvent('recipes', (event) => {
                 'quark:gold_bars',
                 'quark:gold_bars',
                 'betterendforge:terminite_anvil',
-		Item.of('betterendforge:terminite_hammer', '{Damage:0]}').weakNBT(),
+                Item.of('betterendforge:terminite_hammer', '{Damage:0]}').weakNBT(),
                 'minecraft:blast_furnace',
                 'supplementaries:bellows',
                 '#forge:storage_blocks/coal',
@@ -933,29 +933,6 @@ onEvent('recipes', (event) => {
             ],
             result: 'mythicbotany:mana_collector',
             id: `${id_prefix}mana_collector`
-        },
-        {
-            ritual_type: 'occultism:craft_with_spirit_name',
-            activation_item: 'occultism:book_of_binding_bound_djinni',
-            pentacle_id: 'occultism:craft_djinni',
-            duration: 100,
-            ritual_dummy: 'kubejs:craft_logic_director',
-            ingredients: [
-                '#forge:gems/mana_diamond',
-                'botania:bifrost_perm',
-                'powah:ender_core',
-                'botania:bifrost_perm',
-                'integratedterminals:menril_glass',
-                'integratedterminals:menril_glass',
-                'integratedterminals:menril_glass',
-                'integratedterminals:menril_glass',
-                'integratedterminals:chorus_glass',
-                'integratedterminals:chorus_glass',
-                'integratedterminals:chorus_glass',
-                'integratedterminals:chorus_glass'
-            ],
-            result: 'integrateddynamics:logic_director',
-            id: `${id_prefix}logic_director`
         },
         {
             ritual_type: 'occultism:summon',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/storagedrawers/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/storagedrawers/shaped.js
@@ -80,7 +80,7 @@ onEvent('recipes', (event) => {
                 A: '#forge:gears/osmium',
                 B: '#forge:sheetmetals/aluminum',
                 C: '#storagedrawers:drawers',
-                D: '#sophisticatedbackpacks:upgrades/advanced_compacting'
+                D: 'pedestals:coin/compactor3'
             },
             id: 'storagedrawers:compacting_drawers_3'
         },


### PR DESCRIPTION
Attempts to improve some of these crafts, to remove the annoyance of crafting.

Logic Director moved away from the Occultism crafts. Makes it available earlier as well. 
![image](https://user-images.githubusercontent.com/9543430/167280697-193dd328-4138-4ffe-a182-69be25bd3540.png)

Remove Sophisticated Backpacks upgrades from Compacting Drawers
![image](https://user-images.githubusercontent.com/9543430/167280968-e896bbce-854f-4206-b42d-dc9ec187f3c5.png)

Ender Storage no longer requires satchels. Similar gating.
![image](https://user-images.githubusercontent.com/9543430/167281619-03831c5e-e0df-4472-8f64-1fbf37128c87.png)
![image](https://user-images.githubusercontent.com/9543430/167281623-93b15d96-e4f4-4a02-9314-2103b5d2833b.png)
![image](https://user-images.githubusercontent.com/9543430/167281723-fa13ec04-ab35-4d91-abe5-26a576f73f55.png)

Inception Upgrade no longer uses a satchel either:
![image](https://user-images.githubusercontent.com/9543430/167281811-3fed163f-5d6f-43be-8e5a-51b0067568c8.png)

Modular Routers Senders/Pullers
Mk3
![image](https://user-images.githubusercontent.com/9543430/167282070-7fd45790-0afe-4660-a52f-1cb06ea09777.png)

Mk2s
![image](https://user-images.githubusercontent.com/9543430/167282195-2d284869-80a1-4243-9af8-1e608f5a16f1.png)
![image](https://user-images.githubusercontent.com/9543430/167282198-32cc2c7e-8a8e-4d7a-b9be-8a200aa3eb0f.png)

Enchantment Library
![image](https://user-images.githubusercontent.com/9543430/167282275-92dada2d-fdc9-4871-856c-3d511e894f74.png)
