### PR TITLE
[Expert] Re-balance aura recipes

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -503,6 +503,10 @@ onEvent('jei.information', (event) => {
         {
             items: ['naturesaura:projectile_generator'],
             text: [`● Ender Pearls`, `● Llama Spit`, `● Bottles o' Enchanting`, `● Shulker Bullets`, `● Tridents`]
+        },
+        {
+            items: ['naturesaura:birth_spirit'],
+            text: [`Obtained by manually breeding animals in high Aura areas.`]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -2,6 +2,8 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+
+    // Altar's Max Fill rate is 300 aura per tick. If a recipe draws faster than this, it'll still work, but will slow the craft down to that rate if a large enough batch goes through.
     const id_prefix = 'enigmatica:expert/naturesaura/altar/';
     const recipes = [
         {
@@ -40,7 +42,7 @@ onEvent('recipes', (event) => {
             input: 'eidolon:candle',
             output: { item: 'occultism:candle_white' },
             aura_type: 'naturesaura:nether',
-            aura: 50000,
+            aura: 18000,
             time: 60,
             id: 'occultism:crafting/candle'
         },
@@ -48,16 +50,16 @@ onEvent('recipes', (event) => {
             input: 'kubejs:firmament',
             output: { item: 'architects_palette:sunstone' },
             aura_type: 'naturesaura:overworld',
-            aura: 40000,
-            time: 20,
+            aura: 12000,
+            time: 40,
             id: `${id_prefix}sunstone`
         },
         {
             input: 'ars_nouveau:arcane_stone',
             output: { item: 'naturesaura:infused_stone' },
             aura_type: 'naturesaura:nether',
-            aura: 40000,
-            time: 20,
+            aura: 12000,
+            time: 40,
             id: 'naturesaura:altar/infused_stone'
         },
         {
@@ -125,7 +127,7 @@ onEvent('recipes', (event) => {
             output: { item: 'ars_nouveau:warding_stone' },
             aura_type: 'naturesaura:overworld',
             aura: 135000,
-            time: 40,
+            time: 450,
             id: `${id_prefix}warding_stone`
         },
         {
@@ -133,7 +135,7 @@ onEvent('recipes', (event) => {
             output: { item: 'botania:mana_powder', count: 4 },
             aura_type: 'naturesaura:overworld',
             catalyst: { item: 'naturesaura:crushing_catalyst' },
-            aura: 20000,
+            aura: 6000,
             time: 20,
             id: `${id_prefix}mana_powder`
         },
@@ -142,7 +144,7 @@ onEvent('recipes', (event) => {
             output: { item: 'botania:fertilizer' },
             aura_type: 'naturesaura:overworld',
             aura: 50000,
-            time: 20,
+            time: 200,
             id: `${id_prefix}floral_fertilizer`
         },
         {
@@ -206,7 +208,7 @@ onEvent('recipes', (event) => {
             output: { item: 'ars_nouveau:marvelous_clay' },
             aura_type: 'naturesaura:overworld',
             aura: 15000,
-            time: 20,
+            time: 50,
             id: 'ars_nouveau:marvelous_clay'
         },
         {
@@ -214,8 +216,17 @@ onEvent('recipes', (event) => {
             output: { item: 'bloodmagic:slate_ampoule' },
             aura_type: 'naturesaura:nether',
             aura: 15000,
-            time: 20,
+            time: 50,
             id: `${id_prefix}slate_ampoule`
+        },
+        {
+            input: 'ars_nouveau:ritual_fertility',
+            output: { item: 'naturesaura:birth_spirit', count: 8 },
+            catalyst: { item: 'naturesaura:conversion_catalyst' },
+            aura_type: 'naturesaura:overworld',
+            aura: 300000,
+            time: 1000,
+            id: `${id_prefix}birth_spirit`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -141,7 +141,7 @@ onEvent('recipes', (event) => {
         },
         {
             input: 'thermal:phytogro',
-            output: { item: 'botania:fertilizer' },
+            output: { item: 'botania:fertilizer', count: 32 },
             aura_type: 'naturesaura:overworld',
             aura: 50000,
             time: 200,


### PR DESCRIPTION
The natural altar has a cap of 300 aura per tick that it can absorb from the area. With this in mind, a lot of our recipes would end up fully draining the altar, then resulting in a drastic slowdown as it couldn't draw in enough to meet the intended rate.

This re-balances those values a bit to help with this. It also introduces a new recipe to make Spirits of Birthing to resolve #4806

Also adds a tooltip to make it clear that they can still be obtained naturally through manual breeding. If people figure out the trick to automating breeding, so much the better. But this means there's a way forward for folks that miss it.