### PR TITLE
Tinkers Transform Recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/shapeless.js
@@ -8,6 +8,41 @@ onEvent('recipes', (event) => {
         }
     ];
 
+    const tcon_materials = [
+        'rose_gold',
+        'tinkers_bronze',
+        'pig_iron',
+        'slimesteel',
+        'queens_slime',
+        'manyullyn',
+        'hepatizon'
+    ];
+
+    tcon_materials.forEach((material) => {
+        recipes.push(
+            {
+                output: `tconstruct:${material}_block`,
+                inputs: [ `9x #forge:ingots/${material}` ],
+                id: `tconstruct:common/materials/${material}_block_from_ingots`
+            },
+            {
+                output: `9x tconstruct:${material}_ingot`,
+                inputs: [ `#forge:storage_blocks/${material}` ],
+                id: `tconstruct:common/materials/${material}_ingot_from_block`
+            },
+            {
+                output: `tconstruct:${material}_ingot`,
+                inputs: [ `9x #forge:nuggets/${material}` ],
+                id: `tconstruct:common/materials/${material}_ingot_from_nuggets`
+            },
+            {
+                output: `9x tconstruct:${material}_nugget`,
+                inputs: [ `#forge:ingots/${material}` ],
+                id: `tconstruct:common/materials/${material}_nugget_from_ingot`
+            }
+        )
+    });
+
     recipes.forEach((recipe) => {
         event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
     });


### PR DESCRIPTION
The transform (Block <-> Ingot <-> Nugget) recipes for Tinkers Materials were removed in #4727 but don't have EE analogs so they're just gone. This re-adds them, gives us a nice template for anything else like this in the future, and should make it easy to add new Tinkers materials if they occur.