### PR TITLE
Energizing orb recipe for uraninite blocks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/powah/energizing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/powah/energizing.js
@@ -190,6 +190,20 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}uraninite`
         },
         {
+            ingredients: [
+                { tag: 'forge:storage_blocks/uranium' },
+                { tag: 'forge:storage_blocks/uranium' },
+                { tag: 'forge:storage_blocks/sulfur' },
+                { tag: 'forge:storage_blocks/fluorite' }
+            ],
+            energy: 100000,
+            result: {
+                item: 'powah:uraninite_block',
+                count: 2
+            },
+            id: `${id_prefix}uraninite_block`
+        },
+        {
             ingredients: [{ item: 'minecraft:blaze_rod' }],
             energy: 10000000,
             result: {


### PR DESCRIPTION
> implements [this suggestion](https://discord.com/channels/195234321836146688/544822403230859283/975076789678403684) by `GiaruDK` on the enigmatica discord.

![Screen Shot 2022-05-14 at 19 01 04](https://user-images.githubusercontent.com/3179271/168441633-6d2a8df6-5596-40f1-8324-3052e31c99d0.png)

the sulfur dust can't be turned into blocks, without a compacting recipe or another way this pull is fairly useless.