### PR TITLE
Unbind observable by default

### DIFF
--- a/config/defaultoptions/keybindings.txt
+++ b/config/defaultoptions/keybindings.txt
@@ -166,7 +166,7 @@ key_key.mekanism.description:key.keyboard.n:SHIFT
 key_key.mekanism.module_tweaker:key.keyboard.backslash:NONE
 key_key.mekanism.key_boost:key.keyboard.left.control:NONE
 key_key.mekanism.key_hud:key.keyboard.h:NONE
-key_key.observable.profile:key.keyboard.r:NONE
+key_key.observable.profile:key.keyboard.unknown:NONE
 key_key.ship_sail:key.keyboard.unknown:NONE
 key_key.ship_inventory:key.keyboard.unknown:NONE
 key_key.lower_ship_sail:key.keyboard.j:NONE


### PR DESCRIPTION
This button conflicts with (most notably) `JEI`'s recipe mode, as well as the `Lost Trinkets` selection gui.

Since this is a profiler mod (and spark feels more effective) it seems sensible to unbind it for the general populous.
![Screen Shot 2022-05-14 at 19 22 40](https://user-images.githubusercontent.com/3179271/168442196-7a4dbf03-4153-458e-a2ef-1671275ff873.png)

