### PR TITLE
Allow upgrading black hole units/tanks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
@@ -183,7 +183,7 @@ onEvent('recipes', (event) => {
                 B: 'minecraft:ender_eye',
                 C: 'minecraft:ender_pearl',
                 D: 'minecraft:bucket',
-                E: 'thermal:machine_frame'
+                E: 'thermal:fluid_cell_frame'
             },
             id: 'industrialforegoing:common_black_hole_tank'
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
@@ -174,7 +174,31 @@ onEvent('recipes', (event) => {
                 B: 'minecraft:water_bucket'
             },
             id: 'thermal:rubber_from_dandelion'
-        }
+        },
+        {
+            output: 'industrialforegoing:common_black_hole_tank',
+            pattern: ['AAA', 'BCB', 'DED'],
+            key: {
+                A: 'industrialforegoing:plastic',
+                B: 'minecraft:ender_eye',
+                C: 'minecraft:ender_pearl',
+                D: 'minecraft:bucket',
+                E: 'thermal:machine_frame'
+            },
+            id: 'industrialforegoing:common_black_hole_tank'
+        },
+        {
+            output: 'industrialforegoing:common_black_hole_unit',
+            pattern: ['AAA', 'BCB', 'DED'],
+            key: {
+                A: 'industrialforegoing:plastic',
+                B: 'minecraft:ender_eye',
+                C: 'minecraft:ender_pearl',
+                D: '#forge:chests/wooden',
+                E: 'thermal:machine_frame'
+            },
+            id: 'industrialforegoing:common_black_hole_unit'
+        },
     ];
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/shaped.js
@@ -198,7 +198,7 @@ onEvent('recipes', (event) => {
                 E: 'thermal:machine_frame'
             },
             id: 'industrialforegoing:common_black_hole_unit'
-        },
+        }
     ];
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
@@ -3,10 +3,34 @@ onEvent('recipes', (event) => {
         {
             input1: Item.of('aiotbotania:terra_aiot', '{Damage:0}').weakNBT(),
             input2: 'kubejs:quintuple_alfsteel_ingot',
-            output: 'aiotbotania:alfsteel_aiot'
+            output: 'aiotbotania:alfsteel_aiot',
+            id: `aiotbotania:alfsteel_aiot_smithing`
         }
     ];
+
+    const black_hole_types = ['tank', 'unit'];
+    const black_hole_tiers = ['common', 'pity', 'simple', 'advanced', 'supreme'];
+
+    black_hole_types.forEach(type => {
+        black_hole_tiers.forEach((tier, index) => {
+
+            // first tier has no previous tier to upgrade from
+            if(index == 0) return; 
+
+            // no 3 free plastic & enderpearls for expert mode
+            if(index == 1 && global.isExpertMode) return; 
+
+            const prev = black_hole_tiers[index - 1];
+            recipes.push({
+                input1: `industrialforegoing:${prev}_black_hole_${type}`,
+                input2: `industrialforegoing:machine_frame_${tier}`,
+                output: `industrialforegoing:${tier}_black_hole_${type}`,
+                id: `industrialforegoing:${tier}_black_hole_${type}_smithing`
+            });
+        });
+    })
+
     recipes.forEach((recipe) => {
-        event.smithing(recipe.output, recipe.input1, recipe.input2);
+        event.smithing(recipe.output, recipe.input1, recipe.input2).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
@@ -1,10 +1,12 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/smithing/';
+
     const recipes = [
         {
             input1: Item.of('aiotbotania:terra_aiot', '{Damage:0}').weakNBT(),
             input2: 'kubejs:quintuple_alfsteel_ingot',
             output: 'aiotbotania:alfsteel_aiot',
-            id: `aiotbotania:alfsteel_aiot_smithing`
+            id: `${id_prefix}alfsteel_aiot`
         }
     ];
 
@@ -14,15 +16,15 @@ onEvent('recipes', (event) => {
     black_hole_types.forEach(type => {
         black_hole_tiers.forEach((tier, index) => {
 
-            // first tier has no previous tier to upgrade from
-            if(index == 0) return;
+            let lower_tiers = black_hole_tiers.slice(0, index);
 
-            const prev = black_hole_tiers[index - 1];
-            recipes.push({
-                input1: `industrialforegoing:${prev}_black_hole_${type}`,
-                input2: `industrialforegoing:machine_frame_${tier}`,
-                output: `industrialforegoing:${tier}_black_hole_${type}`,
-                id: `industrialforegoing:${tier}_black_hole_${type}_smithing`
+            lower_tiers.forEach(prev => {
+                recipes.push({
+                    input1: `industrialforegoing:${prev}_black_hole_${type}`,
+                    input2: `industrialforegoing:machine_frame_${tier}`,
+                    output: `industrialforegoing:${tier}_black_hole_${type}`,
+                    id: `${id_prefix}upgrade_${prev}_black_hole_${type}_to_${tier}`
+                });
             });
         });
     })

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
@@ -15,10 +15,7 @@ onEvent('recipes', (event) => {
         black_hole_tiers.forEach((tier, index) => {
 
             // first tier has no previous tier to upgrade from
-            if(index == 0) return; 
-
-            // no 3 free plastic & enderpearls for expert mode
-            if(index == 1 && global.isExpertMode) return; 
+            if(index == 0) return;
 
             const prev = black_hole_tiers[index - 1];
             recipes.push({

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shaped.js
@@ -129,19 +129,25 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'industrialforegoing:common_black_hole_tank',
-            pattern: ['AAA', 'A A', 'ABA'],
+            pattern: ['AAA', 'BCB', 'DED'],
             key: {
-                A: '#forge:sheetmetals/aluminum',
-                B: 'thermal:fluid_cell_frame'
+                A: 'industrialforegoing:plastic',
+                B: 'minecraft:ender_eye',
+                C: 'minecraft:ender_pearl',
+                D: 'minecraft:bucket',
+                E: 'thermal:machine_frame'
             },
             id: 'industrialforegoing:common_black_hole_tank'
         },
         {
             output: 'industrialforegoing:common_black_hole_unit',
-            pattern: ['AAA', 'A A', 'ABA'],
+            pattern: ['AAA', 'BCB', 'DED'],
             key: {
-                A: '#forge:sheetmetals/aluminum',
-                B: 'thermal:machine_frame'
+                A: 'industrialforegoing:plastic',
+                B: 'minecraft:ender_eye',
+                C: 'minecraft:ender_pearl',
+                D: '#forge:chests/wooden',
+                E: 'thermal:machine_frame'
             },
             id: 'industrialforegoing:common_black_hole_unit'
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shaped.js
@@ -128,30 +128,6 @@ onEvent('recipes', (event) => {
             id: 'industrialforegoing:potion_brewer'
         },
         {
-            output: 'industrialforegoing:common_black_hole_tank',
-            pattern: ['AAA', 'BCB', 'DED'],
-            key: {
-                A: 'industrialforegoing:plastic',
-                B: 'minecraft:ender_eye',
-                C: 'minecraft:ender_pearl',
-                D: 'minecraft:bucket',
-                E: 'thermal:machine_frame'
-            },
-            id: 'industrialforegoing:common_black_hole_tank'
-        },
-        {
-            output: 'industrialforegoing:common_black_hole_unit',
-            pattern: ['AAA', 'BCB', 'DED'],
-            key: {
-                A: 'industrialforegoing:plastic',
-                B: 'minecraft:ender_eye',
-                C: 'minecraft:ender_pearl',
-                D: '#forge:chests/wooden',
-                E: 'thermal:machine_frame'
-            },
-            id: 'industrialforegoing:common_black_hole_unit'
-        },
-        {
             output: 'industrialforegoing:marine_fisher',
             pattern: ['ABA', 'CDE', 'FGF'],
             key: {


### PR DESCRIPTION
smithing table seems to respect the nbt, "unfortunately" it doesn't return or refund the previous tier of frame:
![Screen Shot 2022-05-14 at 19 46 34](https://user-images.githubusercontent.com/3179271/168443254-7204654d-f277-4500-8b80-50dbe4d41b36.png)

since expert mode overrides the 1st tier to not have plastic/enderpearls in the recipe it cannot be upgraded:
![Screen Shot 2022-05-14 at 19 57 41](https://user-images.githubusercontent.com/3179271/168443308-3d0e7d2f-08a7-4ce0-a6cb-1800b92cdd82.png)

because all the tiers after it require 3 plastic and 3 enderpearls, a notable increase in cost & gating:
![Screen Shot 2022-05-14 at 19 57 51](https://user-images.githubusercontent.com/3179271/168443335-fd85737c-e402-4d91-b796-935bedf989c5.png)


