### PR TITLE
[Expert] Better progression for cloche, insolator, and botany pots

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -577,7 +577,7 @@ onEvent('recipes', (event) => {
                 A: 'thermal:lumium_glass',
                 B: 'immersiveengineering:electron_tube',
                 C: '#forge:treated_wood',
-                D: '#botanypots:botany_pots/simple',
+                D: 'industrialforegoing:hydroponic_bed',
                 E: 'immersiveengineering:component_steel',
                 F: 'pneumaticcraft:fluid_mixer'
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -43,7 +43,16 @@ onEvent('recipes', (event) => {
             id: 'botanypots:crafting/botany_pot'
         },
         {
-            inputs: ['botanypots:botany_pot', 'ars_nouveau:sylph_charm', 'naturesaura:grated_chute'],
+            inputs: [
+                'ars_nouveau:sylph_charm',
+                'botanypots:botany_pot',
+                'astralsorcery:tree_beacon',
+                'botania:enchanted_soil',
+                'botania:enchanted_soil',
+                '#botania:runes/midgard',
+                'naturesaura:grated_chute',
+                '#botania:runes/midgard'
+            ],
             inputFluid: 'materialis:molten_fairy',
             inputFluidAmount: 1296,
             processingTime: 600,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/shaped.js
@@ -301,10 +301,10 @@ onEvent('recipes', (event) => {
             pattern: ['AAA', 'BCB', 'DED'],
             key: {
                 A: 'architects_palette:abyssaline_lamp',
-                B: '#botania:runes/earth',
-                C: 'industrialforegoing:hydroponic_bed',
+                B: '#botania:runes/midgard',
+                C: '#botanypots:botany_pots/simple',
                 D: '#forge:gears/lumium',
-                E: '#forge:circuits/advanced'
+                E: '#industrialforegoing:machine_frame/supreme'
             },
             id: 'thermal:machine_insolator'
         },


### PR DESCRIPTION
Cloche now upgrades the Hydroponic Bed
![image](https://user-images.githubusercontent.com/9543430/168453252-616dfb3d-2ecf-4882-8658-31b0baa07da4.png)

Insolator requires higher tier tech
![image](https://user-images.githubusercontent.com/9543430/168453262-0f778a09-2fbe-49c8-bb1e-db53851cab03.png)

Hopper Botany Pot now requires higher tier magic
![image](https://user-images.githubusercontent.com/9543430/168453266-1a2b995f-e50c-4986-85fb-8462b891cff4.png)

Better resolves #4836