### PR TITLE
Add kubejs helper function `lowerTiers`

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smithing.js
@@ -14,11 +14,9 @@ onEvent('recipes', (event) => {
     const black_hole_tiers = ['common', 'pity', 'simple', 'advanced', 'supreme'];
 
     black_hole_types.forEach(type => {
-        black_hole_tiers.forEach((tier, index) => {
+        black_hole_tiers.forEach(tier => {
 
-            let lower_tiers = black_hole_tiers.slice(0, index);
-
-            lower_tiers.forEach(prev => {
+            lowerTiers(black_hole_tiers, tier).forEach(prev => {
                 recipes.push({
                     input1: `industrialforegoing:${prev}_black_hole_${type}`,
                     input2: `industrialforegoing:machine_frame_${tier}`,
@@ -26,6 +24,7 @@ onEvent('recipes', (event) => {
                     id: `${id_prefix}upgrade_${prev}_black_hole_${type}_to_${tier}`
                 });
             });
+
         });
     })
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/powah/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/powah/shaped.js
@@ -13,14 +13,7 @@ onEvent('recipes', (event) => {
             crystal = 'powah:steel_energized';
         }
 
-        let lowerTiers = [],
-            i = 0,
-            j = powahTiers.indexOf(tier);
-
-        while (i < j) {
-            lowerTiers.push(powahTiers[i]);
-            i++;
-        }
+        let lower_tiers = lowerTiers(powahTiers, tier);
 
         recipes.push(
             {
@@ -29,7 +22,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:energy_cell_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:energy_cell_${item}`))
                 },
                 id: `${id_prefix}energy_cell_${tier}`
             },
@@ -39,7 +32,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:battery_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:battery_${item}`))
                 },
                 id: `${id_prefix}battery_${tier}`
             },
@@ -50,7 +43,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:solar_panel_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:solar_panel_${item}`))
                 },
                 id: `${id_prefix}solar_panel_${tier}`
             }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -538,7 +538,7 @@ onEvent('recipes', (event) => {
         }
     ];
 
-    powahTiers.forEach(function (tier, index) {
+    powahTiers.forEach(function (tier) {
         if (tier == 'starter') {
             return;
         }
@@ -550,14 +550,7 @@ onEvent('recipes', (event) => {
             crystal = 'powah:steel_energized';
         }
 
-        let lowerTiers = [],
-            i = 0,
-            j = powahTiers.indexOf(tier);
-
-        while (i < j) {
-            lowerTiers.push(powahTiers[i]);
-            i++;
-        }
+        // let lower_tiers = lowerTiers(powahTiers, tier);
 
         // Primary Craft
         recipes.push({

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/powah/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/powah/shaped.js
@@ -85,14 +85,7 @@ onEvent('recipes', (event) => {
             wire_coil = 'immersiveengineering:coil_hv';
         }
 
-        let lowerTiers = [],
-            i = 0,
-            j = powahTiers.indexOf(tier);
-
-        while (i < j) {
-            lowerTiers.push(powahTiers[i]);
-            i++;
-        }
+        let lower_tiers = lowerTiers(powahTiers, tier);
 
         // Primary Craft
         recipes.push(
@@ -173,7 +166,7 @@ onEvent('recipes', (event) => {
                     pattern: ['BCB'],
                     key: {
                         B: capacitor,
-                        C: Ingredient.of(lowerTiers.map((item) => `powah:furnator_${item}`))
+                        C: Ingredient.of(lower_tiers.map((item) => `powah:furnator_${item}`))
                     },
                     id: `${id_prefix}furnator_${tier}_upgrade`
                 },
@@ -183,7 +176,7 @@ onEvent('recipes', (event) => {
                     key: {
                         A: wire_coil,
                         B: capacitor,
-                        C: Ingredient.of(lowerTiers.map((item) => `powah:magmator_${item}`))
+                        C: Ingredient.of(lower_tiers.map((item) => `powah:magmator_${item}`))
                     },
                     id: `${id_prefix}magmator_${tier}_upgrade`
                 },
@@ -193,7 +186,7 @@ onEvent('recipes', (event) => {
                     key: {
                         A: `powah:magmator_${tier}`,
                         B: capacitor,
-                        C: Ingredient.of(lowerTiers.map((item) => `powah:thermo_generator_${item}`))
+                        C: Ingredient.of(lower_tiers.map((item) => `powah:thermo_generator_${item}`))
                     },
                     id: `${id_prefix}thermo_generator_${tier}_upgrade`
                 },
@@ -203,7 +196,7 @@ onEvent('recipes', (event) => {
                     key: {
                         A: capacitor,
                         B: `powah:energy_discharger_${tier}`,
-                        C: Ingredient.of(lowerTiers.map((item) => `powah:energy_cell_${item}`))
+                        C: Ingredient.of(lower_tiers.map((item) => `powah:energy_cell_${item}`))
                     },
                     id: `${id_prefix}energy_discharger_${tier}_upgrade`
                 },
@@ -212,7 +205,7 @@ onEvent('recipes', (event) => {
                     pattern: ['A A', 'ABA'],
                     key: {
                         A: capacitor,
-                        B: Ingredient.of(lowerTiers.map((item) => `powah:energy_hopper_${item}`))
+                        B: Ingredient.of(lower_tiers.map((item) => `powah:energy_hopper_${item}`))
                     },
                     id: `${id_prefix}energy_hopper_${tier}_upgrade`
                 },
@@ -221,7 +214,7 @@ onEvent('recipes', (event) => {
                     pattern: [' A ', 'ABA', ' A '],
                     key: {
                         A: capacitor,
-                        B: Ingredient.of(lowerTiers.map((item) => `powah:ender_cell_${item}`))
+                        B: Ingredient.of(lower_tiers.map((item) => `powah:ender_cell_${item}`))
                     },
                     id: `${id_prefix}ender_cell_${tier}_upgrade`
                 }

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -67,3 +67,12 @@ const unificationBlacklist = [
 const playerHas = (item, player) => {
     return player.inventory.find(item) != -1;
 };
+
+// lt  = .slice(0, index)
+// lte = .slice(0, index + 1)
+// gt  = .slice(index)
+// gte = .slice(index + 1)
+
+function lowerTiers(tiers, tier) {
+    return tiers.slice(0, tiers.indexOf(tier));
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/enigmatica/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/enigmatica/shaped.js
@@ -266,14 +266,7 @@ onEvent('recipes', (event) => {
             crystal = 'powah:steel_energized';
         }
 
-        let lowerTiers = [],
-            i = 0,
-            j = powahTiers.indexOf(tier);
-
-        while (i < j) {
-            lowerTiers.push(powahTiers[i]);
-            i++;
-        }
+        let lower_tiers = lowerTiers(powahTiers, tier);
 
         recipes.push(
             {
@@ -282,7 +275,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: capacitor,
                     B: `powah:energy_cable_${tier}`,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:energizing_rod_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:energizing_rod_${item}`))
                 },
                 id: `${id_prefix}powah/energizing_rod_${tier}`
             },
@@ -292,7 +285,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:furnator_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:furnator_${item}`))
                 },
                 id: `${id_prefix}powah/furnator_${tier}`
             },
@@ -302,7 +295,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:magmator_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:magmator_${item}`))
                 },
                 id: `${id_prefix}powah/magmator_${tier}`
             },
@@ -312,7 +305,7 @@ onEvent('recipes', (event) => {
                 key: {
                     A: crystal,
                     B: capacitor,
-                    C: Ingredient.of(lowerTiers.map((item) => `powah:thermo_generator_${item}`))
+                    C: Ingredient.of(lower_tiers.map((item) => `powah:thermo_generator_${item}`))
                 },
                 id: `${id_prefix}powah/thermo_generator_${tier}`
             },
@@ -321,7 +314,7 @@ onEvent('recipes', (event) => {
                 pattern: ['ABA'],
                 key: {
                     A: capacitor,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:energy_hopper_${item}`))
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:energy_hopper_${item}`))
                 },
                 id: `${id_prefix}powah/energy_hopper_${tier}`
             },
@@ -330,7 +323,7 @@ onEvent('recipes', (event) => {
                 pattern: [' A ', ' B ', ' A '],
                 key: {
                     A: capacitor,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:energy_discharger_${item}`))
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:energy_discharger_${item}`))
                 },
                 id: `${id_prefix}powah/energy_discharger_${tier}`
             },
@@ -339,7 +332,7 @@ onEvent('recipes', (event) => {
                 pattern: ['BAB', 'A A', 'BAB'],
                 key: {
                     A: cable,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:ender_gate_${item}`))
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:ender_gate_${item}`))
                 },
                 id: `${id_prefix}powah/ender_gate_${tier}`
             },
@@ -348,7 +341,7 @@ onEvent('recipes', (event) => {
                 pattern: ['BAB', 'A A', 'BAB'],
                 key: {
                     A: capacitor,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:reactor_${item}`))
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:reactor_${item}`))
                 },
                 id: `${id_prefix}powah/reactor_${tier}`
             }

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/powah/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/powah/shaped.js
@@ -15,14 +15,7 @@ onEvent('recipes', (event) => {
             crystal = 'powah:steel_energized';
         }
 
-        let lowerTiers = [],
-            i = 0,
-            j = powahTiers.indexOf(tier);
-
-        while (i < j) {
-            lowerTiers.push(powahTiers[i]);
-            i++;
-        }
+        let lower_tiers = lowerTiers(powahTiers, tier);
 
         recipes.push(
             {
@@ -30,7 +23,7 @@ onEvent('recipes', (event) => {
                 pattern: ['CCC', 'BAB', 'CCC'],
                 key: {
                     A: capacitor,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:energy_cable_${item}`)),
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:energy_cable_${item}`)),
                     C: Ingredient.of('powah:dielectric_rod_horizontal')
                 },
                 id: `powah:crafting/cable_${tier}`
@@ -40,7 +33,7 @@ onEvent('recipes', (event) => {
                 pattern: [' A ', 'ABA', ' A '],
                 key: {
                     A: crystal,
-                    B: Ingredient.of(lowerTiers.map((item) => `powah:ender_cell_${item}`))
+                    B: Ingredient.of(lower_tiers.map((item) => `powah:ender_cell_${item}`))
                 },
                 id: `${id_prefix}ender_cell_${tier}`
             }


### PR DESCRIPTION
Adds a helper function so we don't need to see either:
```
let lowerTiers = [],
    i = 0,
    j = powahTiers.indexOf(tier);

while (i < j) {
    lowerTiers.push(powahTiers[i]);
    i++;
}
```
Or:
```
powahTiers.slice(0, index);
```
But instead:
```
lowerTiers(<tiers>, <tier>);
```
Since the first method looks confusing & slice only a little less.

For future helper functions i have stashed 4 lines of reference on slice.

Also leaving my initial attempt here: (which i abandoned since its uncommon, and i don't know if kubejs likes it much)

```
Object.defineProperty(Array.prototype, 'less_than', {
    value: function(index) {
        return this.slice(0, index);
    }, configurable: true
});
  
Object.defineProperty(Array.prototype, 'less_than_equals', {
    value: function(index) {
        return this.slice(0, index + 1);
    }, configurable: true
});
  
Object.defineProperty(Array.prototype, 'greater_than', {
    value: function(index) {
        return this.slice(index);
    }, configurable: true
});
  
Object.defineProperty(Array.prototype, 'greater_than_equals', {
    value: function(index) {
        return this.slice(index + 1);
    }, configurable: true
});
```