### PR TITLE
Name all the recipes

### DIFF
--- a/.github/actions/ci/kubejs-recipes.js
+++ b/.github/actions/ci/kubejs-recipes.js
@@ -62,5 +62,5 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
     fsp.writeFile(`kubejs/exported/recipes/${group}.json`, JSON.stringify(recipes, null, '\t'));
   }
 
-  console.log(`::notice::${Object.entries(groups['kjs']).length} KubeJS recipes with kjs_, ${Object.entries(groups['md5']).length} KubeJS recipes with md5_, and ${Object.entries(groups['duplicate']).length} duplicates.`)
+  console.log(`::notice::${Object.entries(groups['kjs']).length} KubeJS recipes with kjs_, ${Object.entries(groups['md5']).length} recipes with md5_, and ${Object.entries(groups['duplicate']).length} duplicates.`)
 });

--- a/.github/actions/ci/kubejs-recipes.js
+++ b/.github/actions/ci/kubejs-recipes.js
@@ -22,6 +22,7 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
 
     duplicate: {},
     nameless: {},
+    randomized: {},
   };
 
   lines.forEach(line => {
@@ -49,6 +50,10 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
       groups['nameless'][id] = recipe;      
     }
 
+    if (group == "added" && id.includes('/kjs_')) {
+      groups['randomized'][id] = recipe;      
+    }
+
     groups[group][id] = recipe;
   });
 
@@ -57,5 +62,5 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
     fsp.writeFile(`kubejs/exported/recipes/${group}.json`, JSON.stringify(recipes, null, '\t'));
   }
 
-  console.log(`::notice::${Object.entries(groups['nameless']).length} KubeJS recipes with a randomized name, and ${Object.entries(groups['duplicate']).length} duplicates.`)
+  console.log(`::notice::${Object.entries(groups['nameless']).length} KubeJS recipes with :kjs_, ${Object.entries(groups['randomized']).length} KubeJS recipes with /kjs_, and ${Object.entries(groups['duplicate']).length} duplicates.`)
 });

--- a/.github/actions/ci/kubejs-recipes.js
+++ b/.github/actions/ci/kubejs-recipes.js
@@ -21,8 +21,8 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
     modified: {},
 
     duplicate: {},
-    nameless: {},
-    randomized: {},
+    kjs: {},
+    md5: {},
   };
 
   lines.forEach(line => {
@@ -46,12 +46,12 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
       groups['duplicate'][id] = recipe;      
     }
 
-    if (group == "added" && id.includes(':kjs_')) {
-      groups['nameless'][id] = recipe;      
+    if (group == "added" && id.includes('kjs_')) {
+      groups['kjs'][id] = recipe;      
     }
 
-    if (group == "added" && id.includes('/kjs_')) {
-      groups['randomized'][id] = recipe;      
+    if (group == "added" && id.includes('md5_')) {
+      groups['md5'][id] = recipe;      
     }
 
     groups[group][id] = recipe;
@@ -62,5 +62,5 @@ fsp.readFile('logs/kubejs/server.txt').then(data => {
     fsp.writeFile(`kubejs/exported/recipes/${group}.json`, JSON.stringify(recipes, null, '\t'));
   }
 
-  console.log(`::notice::${Object.entries(groups['nameless']).length} KubeJS recipes with :kjs_, ${Object.entries(groups['randomized']).length} KubeJS recipes with /kjs_, and ${Object.entries(groups['duplicate']).length} duplicates.`)
+  console.log(`::notice::${Object.entries(groups['kjs']).length} KubeJS recipes with kjs_, ${Object.entries(groups['md5']).length} KubeJS recipes with md5_, and ${Object.entries(groups['duplicate']).length} duplicates.`)
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -208,16 +208,16 @@ onEvent('recipes', (event) => {
         event.remove({
             id: `minecraft:${color}_carpet_from_white_carpet`
         });
-        md5(event.shaped(Item.of(`minecraft:${color}_carpet`, 3), ['WW'], {
+        fallback_id(event.shaped(Item.of(`minecraft:${color}_carpet`, 3), ['WW'], {
             W: `minecraft:${color}_wool`
         }), id_prefix);
 
-        md5(event.shaped(Item.of(`minecraft:${color}_stained_glass_pane`, 8), ['GGG', 'GDG', 'GGG'], {
+        fallback_id(event.shaped(Item.of(`minecraft:${color}_stained_glass_pane`, 8), ['GGG', 'GDG', 'GGG'], {
             G: 'minecraft:glass_pane',
             D: dyeTag
         }), id_prefix);
 
-        md5(event.shaped(Item.of(`minecraft:${color}_stained_glass`, 8), ['GGG', 'GDG', 'GGG'], {
+        fallback_id(event.shaped(Item.of(`minecraft:${color}_stained_glass`, 8), ['GGG', 'GDG', 'GGG'], {
             G: 'minecraft:glass',
             D: dyeTag
         }), id_prefix);
@@ -233,11 +233,11 @@ onEvent('recipes', (event) => {
                     event.remove({ id: block });
                 }
 
-                md5(event.shaped(Item.of(block, 8), ['SSS', 'SDS', 'SSS'], {
+                fallback_id(event.shaped(Item.of(block, 8), ['SSS', 'SDS', 'SSS'], {
                     S: itemTag,
                     D: dyeTag
                 }), id_prefix);
-                md5(event.shapeless(Item.of(block, 1), [dyeTag, itemTag]), id_prefix);
+                fallback_id(event.shapeless(Item.of(block, 1), [dyeTag, itemTag]), id_prefix);
             }
         );
 
@@ -263,7 +263,7 @@ onEvent('recipes', (event) => {
             event.shapeless(Item.of(block, 1), [dyeTag, itemTag]).id(`kubejs:${blockName}_${color}`);
         });
 
-        md5(event.shapeless(Item.of(`minecraft:${color}_concrete_powder`, 8), [
+        fallback_id(event.shapeless(Item.of(`minecraft:${color}_concrete_powder`, 8), [
             dyeTag,
             '#forge:sand',
             '#forge:sand',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -584,14 +584,14 @@ onEvent('recipes', (event) => {
     recipes.forEach((recipe) => {
         recipe.id
             ? event.shapeless(recipe.output, recipe.inputs).id(recipe.id)
-            : md5(event.shapeless(recipe.output, recipe.inputs), id_prefix);
+            : fallback_id(event.shapeless(recipe.output, recipe.inputs), id_prefix);
     });
 
     powahTiers.forEach((tier) => {
         if (tier == 'starter') {
             return;
         }
-        md5(event.shapeless(`powah:reactor_${tier}`, `powah:reactor_${tier}`), id_prefix);
+        fallback_id(event.shapeless(`powah:reactor_${tier}`, `powah:reactor_${tier}`), id_prefix);
     });
 
     colors.forEach(function (color) {
@@ -614,12 +614,12 @@ onEvent('recipes', (event) => {
         ]).id(`${id_prefix}dye_hopper_botany_pot_${color}`);
 
         if (color != 'white') {
-            md5(event.shapeless(Item.of(`2x atum:ceramic_slab_${color}`), [
+            fallback_id(event.shapeless(Item.of(`2x atum:ceramic_slab_${color}`), [
                 'atum:ceramic_slab_white',
                 'atum:ceramic_slab_white',
                 `#forge:dyes/${color}`
             ]), id_prefix);
-            md5(event.shapeless(Item.of(`6x atum:ceramic_tile_${color}`), [
+            fallback_id(event.shapeless(Item.of(`6x atum:ceramic_tile_${color}`), [
                 'atum:ceramic_tile_white',
                 'atum:ceramic_tile_white',
                 'atum:ceramic_tile_white',
@@ -628,20 +628,20 @@ onEvent('recipes', (event) => {
                 'atum:ceramic_tile_white',
                 `#forge:dyes/${color}`
             ]), id_prefix);
-            md5(event.shapeless(Item.of(`3x atum:ceramic_stairs_${color}`), [
+            fallback_id(event.shapeless(Item.of(`3x atum:ceramic_stairs_${color}`), [
                 'atum:ceramic_stairs_white',
                 'atum:ceramic_stairs_white',
                 'atum:ceramic_stairs_white',
                 `#forge:dyes/${color}`
             ]), id_prefix);
-            md5(event.shapeless(`atum:ceramic_wall_${color}`, ['atum:ceramic_wall_white', `#forge:dyes/${color}`]), id_prefix);
+            fallback_id(event.shapeless(`atum:ceramic_wall_${color}`, ['atum:ceramic_wall_white', `#forge:dyes/${color}`]), id_prefix);
         }
     });
 
     materialsToUnify.forEach((material) => {
         var ore = Item.of(`emendatusenigmatica:${material}_ore`);
         if (ore.exists) {
-            md5(event.shapeless(ore, `#forge:ores/${material}`), id_prefix);
+            fallback_id(event.shapeless(ore, `#forge:ores/${material}`), id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/architects_palette/warping.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/architects_palette/warping.js
@@ -1,32 +1,35 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/architects_palette/warping/';
+
     const recipes = [
         {
             input: 'minecraft:cactus',
-            output: 'byg:warped_cactus'
+            output: 'byg:warped_cactus',
+            id: `${id_prefix}warped_cactus`
         },
         {
             input: '#forge:coral_blocks',
-            output: 'byg:warped_coral_block'
+            output: 'byg:warped_coral_block',
+            id: `${id_prefix}warped_coral_block`
         },
         {
             input: '#forge:corals',
-            output: 'byg:warped_coral'
+            output: 'byg:warped_coral',
+            id: `${id_prefix}warped_coral`
         },
         {
             input: '#forge:coral_fans',
-            output: 'byg:warped_coral_fan'
+            output: 'byg:warped_coral_fan',
+            id: `${id_prefix}warped_coral_fan`
         }
     ];
 
     recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'architects_palette:warping',
             ingredient: [Ingredient.of(recipe.input)],
             result: Item.of(recipe.output),
             dimension: 'minecraft:the_nether'
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/astralsorcery/altar/';
+
     const recipes = [
         {
             output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:starry_bee"}),
@@ -32,7 +34,8 @@ onEvent('recipes', (event) => {
                 'astralsorcery:built_in_effect_trait_focus_circle',
                 'astralsorcery:altar_default_sparkle',
                 'astralsorcery:built_in_effect_constellation_lines'
-            ]
+            ],
+            id: `${id_prefix}starry_bee_jar`
         }
     ];
 
@@ -58,9 +61,6 @@ onEvent('recipes', (event) => {
             constructed_recipe.recipe_class = recipe.recipe_class;
         }
 
-        const re = event.custom(constructed_recipe);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        event.custom(constructed_recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
@@ -15,7 +15,7 @@ onEvent('recipes', (event) => {
     data.recipes.forEach((recipe) => {
         Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
             if (!input.id.includes('chunk')) {
-                md5(event.custom({
+                fallback_id(event.custom({
                     type: 'astralsorcery:block_transmutation',
                     input: {
                         block: input.id

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/astralsorcery/block_transmutation/';
+
     var data = {
         recipes: [
             { inputTag: '#forge:ores/diamond', output: 'emendatusenigmatica:emerald_ore', starlight: 1000 },
@@ -9,10 +11,11 @@ onEvent('recipes', (event) => {
             }
         ]
     };
+
     data.recipes.forEach((recipe) => {
         Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
             if (!input.id.includes('chunk')) {
-                event.custom({
+                md5(event.custom({
                     type: 'astralsorcery:block_transmutation',
                     input: {
                         block: input.id
@@ -21,7 +24,7 @@ onEvent('recipes', (event) => {
                         block: recipe.output
                     },
                     starlight: recipe.starlight
-                });
+                }), id_prefix);
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
@@ -77,7 +77,7 @@ onEvent('recipes', (event) => {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'astralsorcery:infuser',
             fluidInput: recipe.fluid,
             input: recipe.input,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/astralsorcery/infuser/';
+
     data = {
         recipes: [
             {
@@ -75,7 +77,7 @@ onEvent('recipes', (event) => {
     };
 
     data.recipes.forEach((recipe) => {
-        event.custom({
+        md5(event.custom({
             type: 'astralsorcery:infuser',
             fluidInput: recipe.fluid,
             input: recipe.input,
@@ -88,6 +90,6 @@ onEvent('recipes', (event) => {
             consumeMultipleFluids: false,
             acceptChaliceInput: true,
             copyNBTToOutputs: false
-        });
+        }), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/alloying.js
@@ -30,7 +30,7 @@ onEvent('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'betterendforge:alloying',
             ingredients: recipe.ingredients,
             result: recipe.result,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/alloying.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/betterend/alloying/';
+
     var data = {
         recipes: [
             {
@@ -28,12 +30,12 @@ onEvent('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.custom({
+        md5(event.custom({
             type: 'betterendforge:alloying',
             ingredients: recipe.ingredients,
             result: recipe.result,
             experience: recipe.experience,
             smelttime: recipe.smelttime
-        });
+        }), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/bloodmagic/altar/';
+
     data = {
         recipes: [
             /*{
@@ -8,7 +10,7 @@ onEvent('recipes', (event) => {
                 altarLevel: 0,                      //Altar Level is zero idexed
                 consumptionRate: 5,                 //How much LP is infused per operation
                 drainRate: 5,                       //How much LP is lost per operation when the altar is empty
-                id: 'input item here'
+                id: 'output item here'
             }*/
             
             {
@@ -17,21 +19,20 @@ onEvent('recipes', (event) => {
                 syphon: 50000,
                 altarLevel: 3,
                 consumptionRate: 50,
-                drainRate: 50
+                drainRate: 50,
+                id: `${id_prefix}bloody_bee`
             }
             
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        const re = event.recipes.bloodmagic
+        event.recipes.bloodmagic
             .altar(recipe.output, recipe.input)
             .upgradeLevel(recipe.altarLevel)
             .altarSyphon(recipe.syphon)
             .consumptionRate(recipe.consumptionRate)
-            .drainRate(recipe.drainRate);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+            .drainRate(recipe.drainRate)
+            .id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
@@ -20,7 +20,7 @@ onEvent('recipes', (event) => {
                 altarLevel: 3,
                 consumptionRate: 50,
                 drainRate: 50,
-                id: `${id_prefix}bloody_bee`
+                id: `${id_prefix}bloody_bee_jar`
             }
             
         ]

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
@@ -1,14 +1,18 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/botania/elven_trade/';
+
     const recipes = [
         {
             inputs: [Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee"}).weakNBT().toJson()],
-            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:elven_bee"}).toJson()
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:elven_bee"}).toJson(),
+            id: `${id_prefix}elven_bee`
         },
         {
             inputs: [{ item: 'resourcefulbees:elven_honeycomb' }, { item: 'resourcefulbees:elven_honeycomb' }],
             output: {
                 item: 'botania:elementium_ingot'
-            }
+            },
+            id: `${id_prefix}elementium_ingot`
         },
         {
             inputs: [
@@ -17,18 +21,16 @@ onEvent('recipes', (event) => {
             ],
             output: {
                 item: 'botania:elementium_block'
-            }
+            },
+            id: `${id_prefix}elementium_block`
         }
     ];
 
     recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'botania:elven_trade',
             ingredients: recipe.inputs,
             output: recipe.output
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
@@ -5,7 +5,7 @@ onEvent('recipes', (event) => {
         {
             inputs: [Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee"}).weakNBT().toJson()],
             output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:elven_bee"}).toJson(),
-            id: `${id_prefix}elven_bee`
+            id: `${id_prefix}elven_bee_jar`
         },
         {
             inputs: [{ item: 'resourcefulbees:elven_honeycomb' }, { item: 'resourcefulbees:elven_honeycomb' }],

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
@@ -6,7 +6,7 @@ onEvent('recipes', (event) => {
             input: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:iron_bee"}),
             output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee"}),
             mana: 99999,
-            id: `${id_prefix}mana_bee`
+            id: `${id_prefix}mana_bee_jar`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
@@ -1,9 +1,12 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/botania/mana_infusion/';
+
     const recipes = [
         {
             input: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:iron_bee"}),
             output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee"}),
-            mana: 99999
+            mana: 99999,
+            id: `${id_prefix}mana_bee`
         }
     ];
 
@@ -14,15 +17,14 @@ onEvent('recipes', (event) => {
             output: Item.of(recipe.output).toJson(),
             mana: recipe.mana
         };
+
         if (recipe.catalyst) {
             constructed_recipe.catalyst = {
                 type: 'block',
                 block: recipe.catalyst
             };
         }
-        const re = event.custom(constructed_recipe);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        
+        event.custom(constructed_recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/pure_daisy.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/pure_daisy.js
@@ -1,12 +1,16 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/botania/pure_daisy/';
+
     var data = {
         recipes: [
             {
                 input: 'minecraft:snow_block',
-                output: 'betterendforge:dense_snow'
+                output: 'betterendforge:dense_snow',
+                id: `${id_prefix}dense_snow`
             }
         ]
     };
+
     data.recipes.forEach((recipe) => {
         event.custom({
             type: 'botania:pure_daisy',
@@ -17,6 +21,6 @@ onEvent('recipes', (event) => {
             output: {
                 name: recipe.output
             }
-        });
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
@@ -37,6 +37,6 @@ onEvent('recipes', (event) => {
 
     recipes.forEach((recipe) => {
         recipe.type = 'compote:composting';
-        md5(event.custom(recipe), id_prefix);
+        fallback_id(event.custom(recipe), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/compote/composting.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/compote/composting/';
+
     const recipes = [
         /*
         {
@@ -35,6 +37,6 @@ onEvent('recipes', (event) => {
 
     recipes.forEach((recipe) => {
         recipe.type = 'compote:composting';
-        event.custom(recipe);
+        md5(event.custom(recipe), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/emptying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/emptying.js
@@ -1,9 +1,12 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/create/emptying/';
+
     const recipes = [
         {
             input: 'farmersdelight:milk_bottle',
             container: 'minecraft:glass_bottle',
-            fluid: Fluid.of('minecraft:milk', 250)
+            fluid: Fluid.of('minecraft:milk', 250),
+            id: `${id_prefix}milk_bottle`
         }
     ];
 
@@ -20,9 +23,6 @@ onEvent('recipes', (event) => {
     });
 
     recipes.forEach((recipe) => {
-        const re = event.recipes.create.emptying([recipe.fluid, recipe.container], recipe.input);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        event.recipes.create.emptying([recipe.fluid, recipe.container], recipe.input).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/pressing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/pressing.js
@@ -1,9 +1,15 @@
 onEvent('recipes', (event) => {
-    const recipes = [{ output: 'mekanism:hdpe_sheet', inputs: ['mekanism:hdpe_pellet'] }];
+    const id_prefix = 'enigmatica:base/create/pressing/';
+
+    const recipes = [
+        {
+            output: 'mekanism:hdpe_sheet',
+            inputs: ['mekanism:hdpe_pellet'],
+            id: `${id_prefix}hdpe_sheet`
+        }
+    ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            ? event.recipes.create.pressing(recipe.output, recipe.inputs).id(recipe.id)
-            : event.recipes.create.pressing(recipe.output, recipe.inputs);
+        event.recipes.create.pressing(recipe.output, recipe.inputs).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cutting.js
@@ -80,7 +80,7 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        md5(event.custom(recipe), id_prefix);
+        fallback_id(event.custom(recipe), id_prefix);
     });
 
     const tillsIntoFarmland = [
@@ -107,7 +107,7 @@ onEvent('recipes', (event) => {
             let ingredients = Ingredient.of(soil);
             let result = [Item.of(farmland)];
 
-            md5(event.custom({
+            fallback_id(event.custom({
                 type: 'farmersdelight:cutting',
                 ingredients: [ingredients],
                 tool: tool,
@@ -138,7 +138,7 @@ onEvent('recipes', (event) => {
 
             event.remove({ mod: 'farmersdelight', output: recipe.output });
 
-            md5(event.custom({
+            fallback_id(event.custom({
                 type: 'farmersdelight:cutting',
                 ingredients: [ingredients],
                 tool: tool,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
@@ -111,7 +111,7 @@ onEvent('recipes', (event) => {
         if (recipe.id) {
             re.id(recipe.id);
         } else {
-            md5(re, id_prefix);
+            fallback_id(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/crusher/';
+
     var data = {
         recipes: [
             {
@@ -105,8 +107,11 @@ onEvent('recipes', (event) => {
 
     data.recipes.forEach((recipe) => {
         const re = event.recipes.immersiveengineering.crusher(recipe.output, recipe.input, recipe.secondary);
+        
         if (recipe.id) {
             re.id(recipe.id);
+        } else {
+            md5(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fermenter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fermenter.js
@@ -82,7 +82,7 @@ onEvent('recipes', (event) => {
 	*/
 
     lowAmountInputs.forEach((input) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'immersiveengineering:fermenter',
             fluid: {
                 fluid: 'immersiveengineering:ethanol',
@@ -95,7 +95,7 @@ onEvent('recipes', (event) => {
         }), `${id_prefix}low/`);
     });
     normalAmountInputs.forEach((input) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'immersiveengineering:fermenter',
             fluid: {
                 fluid: 'immersiveengineering:ethanol',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fermenter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fermenter.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/fermenter/';
+
     const lowAmountInputs = [
         'farmersdelight:pumpkin_slice',
         'simplefarming:cantaloupe',
@@ -80,7 +82,7 @@ onEvent('recipes', (event) => {
 	*/
 
     lowAmountInputs.forEach((input) => {
-        event.custom({
+        md5(event.custom({
             type: 'immersiveengineering:fermenter',
             fluid: {
                 fluid: 'immersiveengineering:ethanol',
@@ -90,10 +92,10 @@ onEvent('recipes', (event) => {
                 item: input
             },
             energy: 1600
-        });
+        }), `${id_prefix}low/`);
     });
     normalAmountInputs.forEach((input) => {
-        event.custom({
+        md5(event.custom({
             type: 'immersiveengineering:fermenter',
             fluid: {
                 fluid: 'immersiveengineering:ethanol',
@@ -103,6 +105,6 @@ onEvent('recipes', (event) => {
                 item: input
             },
             energy: 6400
-        });
+        }), `${id_prefix}high/`);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fertilizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fertilizer.js
@@ -1,32 +1,32 @@
 onEvent('recipes', (event) => {
-    const id_prefix = 'enigmatica:base/immersiveengineering/fertilizer';
+    const id_prefix = 'enigmatica:base/immersiveengineering/fertilizer/';
 
     var data = {
         recipes: [
             {
                 input: 'industrialforegoing:fertilizer',
                 growthModifier: 1.7,
-                id: `${id_prefix}/fertilizer`
+                id: `${id_prefix}fertilizer`
             },
             {
                 input: 'thermal:phytogro',
                 growthModifier: 3.0,
-                id: `${id_prefix}/phyto_gro`
+                id: `${id_prefix}phyto_gro`
             },
             {
                 input: 'botania:fertilizer',
                 growthModifier: 1.5,
-                id: `${id_prefix}/floral_fertilizer`
+                id: `${id_prefix}floral_fertilizer`
             },
             {
                 input: 'farmingforblockheads:red_fertilizer',
                 growthModifier: 2.0,
-                id: `${id_prefix}/red_fertilizer`
+                id: `${id_prefix}red_fertilizer`
             },
             {
                 input: 'farmingforblockheads:green_fertilizer',
                 growthModifier: 1.5,
-                id: `${id_prefix}/green_fertilizer`
+                id: `${id_prefix}green_fertilizer`
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fertilizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/fertilizer.js
@@ -1,29 +1,37 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/fertilizer';
+
     var data = {
         recipes: [
             {
                 input: 'industrialforegoing:fertilizer',
-                growthModifier: 1.7
+                growthModifier: 1.7,
+                id: `${id_prefix}/fertilizer`
             },
             {
                 input: 'thermal:phytogro',
-                growthModifier: 3.0
+                growthModifier: 3.0,
+                id: `${id_prefix}/phyto_gro`
             },
             {
                 input: 'botania:fertilizer',
-                growthModifier: 1.5
+                growthModifier: 1.5,
+                id: `${id_prefix}/floral_fertilizer`
             },
             {
                 input: 'farmingforblockheads:red_fertilizer',
-                growthModifier: 2.0
+                growthModifier: 2.0,
+                id: `${id_prefix}/red_fertilizer`
             },
             {
                 input: 'farmingforblockheads:green_fertilizer',
-                growthModifier: 1.5
+                growthModifier: 1.5,
+                id: `${id_prefix}/green_fertilizer`
             }
         ]
     };
+    
     data.recipes.forEach((recipe) => {
-        event.recipes.immersiveengineering.fertilizer(recipe.input).growthModifier(recipe.growthModifier);
+        event.recipes.immersiveengineering.fertilizer(recipe.input).growthModifier(recipe.growthModifier).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/metal_press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/metal_press.js
@@ -1,11 +1,16 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/metal_press/';
+
     const recipes = [
-        { output: 'mekanism:hdpe_sheet', input: 'mekanism:hdpe_pellet', mold: '#thermal:crafting/dies/plate' }
+        {
+            output:'mekanism:hdpe_sheet',
+            input: 'mekanism:hdpe_pellet',
+            mold: '#thermal:crafting/dies/plate',
+            id: `${id_prefix}hdpe_sheet`
+        }
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            ? event.recipes.immersiveengineering.metal_press(recipe.output, recipe.input, recipe.mold).id(recipe.id)
-            : event.recipes.immersiveengineering.metal_press(recipe.output, recipe.input, recipe.mold);
+        event.recipes.immersiveengineering.metal_press(recipe.output, recipe.input, recipe.mold).id(recipe.id)
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/squeezer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/squeezer.js
@@ -86,7 +86,7 @@ onEvent('recipes', (event) => {
 
     recipes.forEach((input) => {
         input.inputs.forEach((seed) => {
-            md5(event.custom({
+            fallback_id(event.custom({
                 type: 'immersiveengineering:squeezer',
                 fluid: {
                     fluid: 'immersiveengineering:plantoil',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/squeezer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/squeezer.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/immersiveengineering/squeezer/';
+
     const recipes = [
         {
             inputs: [
@@ -84,7 +86,7 @@ onEvent('recipes', (event) => {
 
     recipes.forEach((input) => {
         input.inputs.forEach((seed) => {
-            event.custom({
+            md5(event.custom({
                 type: 'immersiveengineering:squeezer',
                 fluid: {
                     fluid: 'immersiveengineering:plantoil',
@@ -94,7 +96,7 @@ onEvent('recipes', (event) => {
                     item: seed
                 },
                 energy: 6400
-            });
+            }), id_prefix);
         });
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -98,7 +98,7 @@ onEvent('recipes', (event) => {
         if (recipe.id) {
             re.id(recipe.id);
         } else {
-            md5(re, id_prefix);
+            fallback_id(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/industrialforegoing/dissolution_chamber/';
+
     const recipes = [
         /*
         {
@@ -95,6 +97,8 @@ onEvent('recipes', (event) => {
 
         if (recipe.id) {
             re.id(recipe.id);
+        } else {
+            md5(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
@@ -97,7 +97,7 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'interactio:item_fluid_transform',
             inputs: recipe.inputs,
             fluid: recipe.fluid,
@@ -107,7 +107,7 @@ onEvent('recipes', (event) => {
     });
 
     simpleTagRecipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'interactio:item_fluid_transform',
             inputs: [{ tag: recipe.input, count: 1, return_chance: 0 }],
             fluid: { fluid: 'minecraft:water' },
@@ -121,7 +121,7 @@ onEvent('recipes', (event) => {
     });
 
     simpleItemRecipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'interactio:item_fluid_transform',
             inputs: [{ item: recipe.input, count: 1, return_chance: 0 }],
             fluid: { fluid: 'minecraft:water' },
@@ -136,7 +136,7 @@ onEvent('recipes', (event) => {
 
     rustyItems.forEach((rustyItem) => {
         let unrustedItem = rustyItem.replace('rusty_', '');
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'interactio:item_fluid_transform',
             inputs: [{ item: unrustedItem, count: 1, return_chance: 0 }],
             fluid: { fluid: 'minecraft:water' },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/injecting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/injecting.js
@@ -1,9 +1,12 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/mekanism/injecting/';
+
     const recipes = [
         {
             output: 'buildinggadgets:construction_block_dense',
             input: 'buildinggadgets:construction_block_powder',
-            gas: { tag: 'mekanism:water_vapor', amount: 1 }
+            gas: { tag: 'mekanism:water_vapor', amount: 1 },
+            id: `${id_prefix}construction_block_powder_to_dense`,
         },
         {
             output: 'minecraft:clay',
@@ -19,9 +22,6 @@ onEvent('recipes', (event) => {
         }
     ];
     recipes.forEach((recipe) => {
-        const re = event.recipes.mekanism.injecting(recipe.output, recipe.input, recipe.gas);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        event.recipes.mekanism.injecting(recipe.output, recipe.input, recipe.gas).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/metallurgic_infusing.js
@@ -1,10 +1,13 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/mekanism/metallurgic_infusing/';
+
     const recipes = [
         {
             output: 'betterendforge:end_mycelium',
             input: 'minecraft:end_stone',
             infusionInput: 'mekanism:fungi',
-            infusionAmount: 10
+            infusionAmount: 10,
+            id: `${id_prefix}end_stone_to_end_mycelium`
         },
         {
             output: 'minecraft:crimson_nylium',
@@ -16,15 +19,11 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            ? event.recipes.mekanism
-                  .metallurgic_infusing(recipe.output, recipe.input, recipe.infusionInput, recipe.infusionAmount)
-                  .id(recipe.id)
-            : event.recipes.mekanism.metallurgic_infusing(
-                  recipe.output,
-                  recipe.input,
-                  recipe.infusionInput,
-                  recipe.infusionAmount
-              );
+        event.recipes.mekanism.metallurgic_infusing(
+            recipe.output,
+            recipe.input,
+            recipe.infusionInput,
+            recipe.infusionAmount
+        ).id(recipe.id)
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
@@ -137,6 +137,6 @@ onEvent('recipes', (event) => {
     });
 
     recipes.forEach((recipe) => {
-        md5(event.stonecutting(recipe.output, recipe.input), id_prefix);
+        fallback_id(event.stonecutting(recipe.output, recipe.input), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/offering.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/offering.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/naturesaura/offering/';
+
     const data = {
         recipes: [
             /*{
@@ -12,7 +14,7 @@ onEvent('recipes', (event) => {
                     item: 'naturesaura:infused_iron',
                     count: 3,
                 },
-                id: ''
+                id: `${id_prefix}`
             }*/
             {
                 input: {
@@ -24,20 +26,18 @@ onEvent('recipes', (event) => {
                 output: {
                     item: 'naturesaura:sky_ingot',
                     count: 3
-                }
+                },
+                id: `${id_prefix}sky_ingot_from_honeycomb`
             }
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'naturesaura:offering',
             input: recipe.input,
             start_item: recipe.start_item,
             output: recipe.output
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/assembly.js
@@ -1,18 +1,23 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/pneumaticcraft/assembly_/';
+
     recipes = [
         {
             input: '#forge:ingots/compressed_iron',
             input_count: 4,
             output: { item: 'pneumaticcraft:elevator_frame', count: 8 },
-            program: 'drill'
+            program: 'drill',
+            id: `${id_prefix}elevator_frame`
         },
         {
             input: 'pneumaticcraft:reinforced_brick_wall',
             input_count: 6,
             output: { item: 'pneumaticcraft:cannon_barrel', count: 2 },
-            program: 'drill'
+            program: 'drill',
+            id: `${id_prefix}cannon_barrel`
         }
     ];
+
     recipes.forEach((recipe) => {
         let constructed_input = recipe.input.charAt(0) == '#' ? { tag: recipe.input.slice(1) } : { item: recipe.input };
         if (recipe.input_count) {
@@ -20,14 +25,11 @@ onEvent('recipes', (event) => {
             constructed_input.count = recipe.input_count;
         }
 
-        let re = event.custom({
+        event.custom({
             type: `pneumaticcraft:assembly_${recipe.program}`,
             input: constructed_input,
             result: recipe.output,
             program: recipe.program
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id.replace('assembly_', `assembly_${recipe.program}`));
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/pneumaticcraft/fuel_quantity/';
+
     var multiplier = 1000;
     var data = {
         recipes: [
@@ -25,7 +27,7 @@ onEvent('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.custom({
+        md5(event.custom({
             type: 'pneumaticcraft:fuel_quality',
             fluid: {
                 type: 'pneumaticcraft:fluid',
@@ -34,6 +36,6 @@ onEvent('recipes', (event) => {
             },
             air_per_bucket: recipe.air * multiplier,
             burn_rate: recipe.rate
-        });
+        }), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
@@ -27,7 +27,7 @@ onEvent('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'pneumaticcraft:fuel_quality',
             fluid: {
                 type: 'pneumaticcraft:fluid',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/centrifuge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/centrifuge.js
@@ -101,7 +101,7 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'resourcefulbees:centrifuge',
             ingredient: recipe.ingredient,
             results: recipe.results,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/centrifuge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/centrifuge.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/resourcefulbees/centrifuge/';
+
     const recipes = [
         {
             ingredient: {
@@ -99,12 +101,12 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        event.custom({
+        md5(event.custom({
             type: 'resourcefulbees:centrifuge',
             ingredient: recipe.ingredient,
             results: recipe.results,
             time: recipe.time,
             noBottleInput: recipe.noBottleInput
-        });
+        }), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/tconstruct/casting_table/';
+
     const recipes = [
         /*{
             cast: {
@@ -23,7 +25,7 @@ onEvent('recipes', (event) => {
             },
             result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:cobalt_bee"}).toResultJson(),
             cooling_time: 200,
-            id: 'tconstruct:kjs_cobalt_bee_jar'
+            id: `${id_prefix}cobalt_bee_jar`
         },
         {
             cast: {
@@ -36,7 +38,7 @@ onEvent('recipes', (event) => {
             },
             result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:skyslime_bee"}).toResultJson(),
             cooling_time: 100,
-            id: 'tconstruct:kjs_skyslime_bee_jar'
+            id: `${id_prefix}skyslime_bee_jar`
         },
         {
             cast: {
@@ -49,7 +51,7 @@ onEvent('recipes', (event) => {
             },
             result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:ichor_bee"}).toResultJson(),
             cooling_time: 100,
-            id: 'tconstruct:kjs_ichor_bee_jar'
+            id: `${id_prefix}ichor_bee_jar`
         },
         {
             cast: {
@@ -62,21 +64,18 @@ onEvent('recipes', (event) => {
             },
             result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:enderslime_bee"}).toResultJson(),
             cooling_time: 100,
-            id: 'tconstruct:kjs_enderslime_bee_jar'
+            id: `${id_prefix}enderslime_bee_jar`
         }
     ];
 
     recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'tconstruct:casting_table',
             cast: recipe.cast,
             cast_consumed: recipe.cast_consumed,
             fluid: recipe.fluid,
             result: recipe.result,
             cooling_time: recipe.cooling_time
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/melting_fuel.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/melting_fuel.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/tconstruct/melting_fuel/';
+
     const recipes = [
         {
             fluid: {
@@ -6,19 +8,17 @@ onEvent('recipes', (event) => {
                 amount: 50
             },
             duration: 150,
-            temperature: 1500
+            temperature: 1500,
+            id: `${id_prefix}blaze_honey`
         }
     ];
 
     recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'tconstruct:melting_fuel',
             fluid: recipe.fluid,
             duration: recipe.duration,
             temperature: recipe.temperature
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
@@ -25,6 +25,6 @@ onEvent('recipes', (event) => {
     };
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
+        fallback_id(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/compression_fuel/';
+
     var multiplier = 10;
     var data = {
         recipes: [
@@ -23,6 +25,6 @@ onEvent('recipes', (event) => {
     };
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier);
+        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/lapidary_fuel/';
+
     event.remove({ type: 'thermal:lapidary_fuel' });
     var multiplier = 40;
     var data = {
@@ -18,7 +20,8 @@ onEvent('recipes', (event) => {
             { input: '#forge:gems/amber', energy: 160000 }
         ]
     };
+
     data.recipes.forEach((recipe) => {
-        event.recipes.thermal.lapidary_fuel(recipe.input).energy(recipe.energy * multiplier);
+        event.recipes.thermal.lapidary_fuel(recipe.input).energy(recipe.energy * multiplier).id(`${id_prefix}${recipe.input.replace('#forge:gems/', '')}`);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/magmatic.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/magmatic.js
@@ -1,12 +1,15 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/magmatic_fuel/';
+
     var multiplier = 10;
     const recipes = [
         {
             input: 'tconstruct:blazing_blood',
-            energy: 1000000
+            energy: 1000000,
+            id: `${id_prefix}blazing_blood`
         }
     ];
     recipes.forEach((recipe) => {
-        event.recipes.thermal.magmatic_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier);
+        event.recipes.thermal.magmatic_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator_catalyst.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator_catalyst.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/insolator_catalyst/';
+
     var data = {
         recipes: [
             {
@@ -7,7 +9,8 @@ onEvent('recipes', (event) => {
                 secondaryMod: 2.0,
                 energyMod: 0.8,
                 minChance: 0.8,
-                useChance: 0.8
+                useChance: 0.8,
+                id: `${id_prefix}fertilizer`
             },
             {
                 input: 'botania:fertilizer',
@@ -15,18 +18,21 @@ onEvent('recipes', (event) => {
                 secondaryMod: 1.7,
                 energyMod: 0.9,
                 minChance: 0.5,
-                useChance: 0.5
+                useChance: 0.5,
+                id: `${id_prefix}floral_fertilizer`
             },
             {
-                input: 'farmingforblockheads:red_fertilizer',
+                input: 'farmingforblockheads:red_fertilizer', // no green fertilizer here too?
                 primaryMod: 2.3,
                 secondaryMod: 2.3,
                 energyMod: 0.8,
                 minChance: 0.15,
-                useChance: 0.15
+                useChance: 0.15,
+                id: `${id_prefix}red_fertilizer`
             }
         ]
     };
+
     data.recipes.forEach((recipe) => {
         event.recipes.thermal
             .insolator_catalyst(recipe.input)
@@ -34,6 +40,7 @@ onEvent('recipes', (event) => {
             .secondaryMod(recipe.secondaryMod)
             .energyMod(recipe.energyMod)
             .minChance(recipe.minChance)
-            .useChance(recipe.useChance);
+            .useChance(recipe.useChance)
+            .id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
@@ -1,9 +1,11 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/tree_extractor/';
+
     treeRegistry.forEach((treeCategories) => {
         treeCategories.trees.forEach((tree) => {
             if (tree.sap) {
                 if (tree.rate.living > 0) {
-                    event.custom({
+                    md5(event.custom({
                         type: 'thermal:tree_extractor',
                         trunk: tree.trunk,
                         leaves: tree.leaf,
@@ -11,7 +13,7 @@ onEvent('recipes', (event) => {
                             fluid: tree.sap,
                             amount: tree.rate.living
                         }
-                    });
+                    }), id_prefix);
                 }
             }
         });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor.js
@@ -5,7 +5,7 @@ onEvent('recipes', (event) => {
         treeCategories.trees.forEach((tree) => {
             if (tree.sap) {
                 if (tree.rate.living > 0) {
-                    md5(event.custom({
+                    fallback_id(event.custom({
                         type: 'thermal:tree_extractor',
                         trunk: tree.trunk,
                         leaves: tree.leaf,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor_boost.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/tree_extractor_boost.js
@@ -1,4 +1,6 @@
 onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/thermal/tree_extractor_boost/';
+
     var data = {
         recipes: [
             {
@@ -7,12 +9,13 @@ onEvent('recipes', (event) => {
                     item: 'industrialforegoing:fertilizer'
                 },
                 output: 1.7,
-                cycles: 12
+                cycles: 12,
+                id: `${id_prefix}fertilizer`
             }
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        event.custom(recipe);
+        event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
@@ -40,7 +40,7 @@ function botania_dye_pestle_mortar(event, recipe, id_prefix) {
         output = Item.of(recipe.primary, count),
         inputs = [recipe.input, 'botania:pestle_and_mortar'];
 
-    md5(event.shapeless(output, inputs), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.shapeless(output, inputs), `${id_prefix}${arguments.callee.name}/`);
 }
 
 function create_dye_milling(event, recipe, id_prefix) {
@@ -58,7 +58,7 @@ function create_dye_milling(event, recipe, id_prefix) {
         ],
         input = recipe.input;
 
-    md5(event.recipes.create.milling(outputs, input), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.recipes.create.milling(outputs, input), `${id_prefix}${arguments.callee.name}/`);
 }
 
 function immersiveengineering_dye_crusher(event, recipe, id_prefix) {
@@ -75,7 +75,7 @@ function immersiveengineering_dye_crusher(event, recipe, id_prefix) {
         ],
         input = recipe.input;
 
-    md5(event.recipes.immersiveengineering.crusher(output, input, extras), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.recipes.immersiveengineering.crusher(output, input, extras), `${id_prefix}${arguments.callee.name}/`);
 }
 
 // function integrateddynamics_dye_squeezing(event, recipe, id_prefix) {
@@ -102,7 +102,7 @@ function immersiveengineering_dye_crusher(event, recipe, id_prefix) {
 //         }
 //     });
 
-//     md5(event.custom({
+//     fallback_id(event.custom({
 //         type: 'integrateddynamics:mechanical_squeezer',
 //         item: {
 //             item: recipe.input
@@ -129,7 +129,7 @@ function mekanism_dye_enriching(event, recipe, id_prefix) {
         output = Item.of(recipe.primary, count),
         input = recipe.input;
 
-    md5(event.recipes.mekanism.enriching(output, input), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.recipes.mekanism.enriching(output, input), `${id_prefix}${arguments.callee.name}/`);
 }
 
 function mekanism_pigment_extracting(event, recipe, id_prefix) {
@@ -145,7 +145,7 @@ function mekanism_pigment_extracting(event, recipe, id_prefix) {
     let dye_color = recipe.primary.split(':')[1].replace('_dye', '');
     let count = baseCount * multiplier;
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'mekanism:pigment_extracting',
         input: { ingredient: { item: recipe.input } },
         output: { pigment: `mekanism:${dye_color}`, amount: 256 * count }
@@ -167,7 +167,7 @@ function pedestals_dye_crushing(event, recipe, id_prefix) {
         output = recipe.primary,
         input = recipe.input;
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'pedestals:pedestal_crushing',
         ingredient: { item: input },
         result: { item: output, count: count }
@@ -193,7 +193,7 @@ function thermal_dye_centrifuge(event, recipe, id_prefix) {
         ],
         input = recipe.input;
 
-    md5(event.recipes.thermal.centrifuge(outputs, input), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.recipes.thermal.centrifuge(outputs, input), `${id_prefix}${arguments.callee.name}/`);
 }
 
 function atum_quern_milling(event, recipe, id_prefix) {
@@ -208,7 +208,7 @@ function atum_quern_milling(event, recipe, id_prefix) {
         input = recipe.input,
         rotations = 1 * multiplier;
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'atum:quern',
         ingredient: { item: input },
         result: { item: output, count: count },
@@ -223,7 +223,7 @@ function shapeless_dye_crafting(event, recipe, id_prefix) {
     var output = Item.of(recipe.primary),
         inputs = [recipe.input];
 
-    md5(event.shapeless(output, inputs), `${id_prefix}${arguments.callee.name}/`);
+    fallback_id(event.shapeless(output, inputs), `${id_prefix}${arguments.callee.name}/`);
 }
 
 function occultism_dye_crushing(event, recipe, id_prefix) {
@@ -241,7 +241,7 @@ function occultism_dye_crushing(event, recipe, id_prefix) {
         output = recipe.primary,
         input = recipe.input;
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'occultism:crushing',
         ingredient: { item: input },
         result: { item: output, count: count },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
@@ -43,7 +43,7 @@ function soils_botany_pots(event, soil) {
         display.properties = { moisture: 7 };
     }
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'botanypots:soil',
         input: { item: input },
         display: display,
@@ -134,7 +134,7 @@ function crops_botany_pots(event, type, crop) {
         });
     }
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'botanypots:crop',
         seed: { item: input },
         categories: [crop.substrate],
@@ -227,7 +227,7 @@ function crops_thermal_insolator(event, type, crop) {
         outputs.push(Item.of(plantSecondary).chance(secondaryChance));
     }
 
-    md5(event.recipes.thermal
+    fallback_id(event.recipes.thermal
         .insolator(outputs, input)
         .water(baseWater * waterModifier)
         .energy(baseEnergy * energyModifier), `enigmatica:base/unification/unify_growables/${arguments.callee.name}/`);
@@ -409,7 +409,7 @@ function crops_immersiveengineering_cloche(event, type, crop) {
         //add any secondary
         outputs.push(Item.of(plantSecondary, secondaryCount));
     }
-    md5(event.recipes.immersiveengineering
+    fallback_id(event.recipes.immersiveengineering
         .cloche(outputs, input, substrate, {
             type: renderType,
             block: renderBlock
@@ -493,7 +493,7 @@ function trees_botany_pots(event, type, tree) {
         growthModifier = 0.5;
     }
 
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'botanypots:crop',
         seed: { item: input },
         categories: [tree.substrate],
@@ -532,7 +532,7 @@ function trees_thermal_insolator(event, tree) {
         outputs.push(Item.of(tree.extraDecoration).chance(extraDecorationRate));
     }
 
-    md5(event.recipes.thermal
+    fallback_id(event.recipes.thermal
         .insolator(outputs, input)
         .water(baseWater * waterModifier)
         .energy(baseEnergy * energyModifier), `enigmatica:base/unification/unify_growables/${arguments.callee.name}/`);
@@ -613,7 +613,7 @@ function trees_immersiveengineering_cloche(event, tree) {
         outputs.push(Item.of(tree.extraDecoration, extraDecorationRate));
     }
     
-    md5(event.recipes.immersiveengineering
+    fallback_id(event.recipes.immersiveengineering
         .cloche(outputs, input, substrate, {
             type: renderType,
             block: renderBlock

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
@@ -43,13 +43,13 @@ function soils_botany_pots(event, soil) {
         display.properties = { moisture: 7 };
     }
 
-    fallback_id(event.custom({
+    event.custom({
         type: 'botanypots:soil',
         input: { item: input },
         display: display,
         categories: soil.categories,
         growthModifier: soil.growthModifier
-    }), `enigmatica:base/unification/unify_growables/${arguments.callee.name}/`);
+    });
 }
 
 function crops_botany_pots(event, type, crop) {
@@ -134,14 +134,14 @@ function crops_botany_pots(event, type, crop) {
         });
     }
 
-    fallback_id(event.custom({
+    event.custom({
         type: 'botanypots:crop',
         seed: { item: input },
         categories: [crop.substrate],
         growthTicks: growthTicks * growthModifier,
         display: { block: crop.render },
         results: outputs
-    }), `enigmatica:base/unification/unify_growables/${arguments.callee.name}/`);
+    });
 }
 
 function crops_thermal_insolator(event, type, crop) {
@@ -493,14 +493,14 @@ function trees_botany_pots(event, type, tree) {
         growthModifier = 0.5;
     }
 
-    fallback_id(event.custom({
+    event.custom({
         type: 'botanypots:crop',
         seed: { item: input },
         categories: [tree.substrate],
         growthTicks: growthTicks * growthModifier,
         display: { block: input },
         results: outputs
-    }), `enigmatica:base/unification/unify_growables/${arguments.callee.name}/`);
+    });
 }
 
 function trees_thermal_insolator(event, tree) {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -127,7 +127,7 @@ onEvent('recipes', (event) => {
                 break;
         }
 
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'astralsorcery:infuser',
             fluidInput: 'astralsorcery:liquid_starlight',
             input: {
@@ -150,7 +150,7 @@ onEvent('recipes', (event) => {
             return;
         }
         var tag = `forge:ores/${material}`;
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'betterendforge:alloying',
             ingredients: [{ tag: tag }, { tag: tag }],
             result: Ingredient.of(ingot, 3),
@@ -240,7 +240,7 @@ onEvent('recipes', (event) => {
         }
 
         // Alchemy Table Processing
-        md5(event.recipes.bloodmagic.alchemytable(Item.of(output, count), inputs).syphon(400).ticks(200).upgradeLevel(1), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.recipes.bloodmagic.alchemytable(Item.of(output, count), inputs).syphon(400).ticks(200).upgradeLevel(1), `${id_prefix}${arguments.callee.name}/`);
     }
     function bloodmagic_ingot_gem_crushing(event, material, ingot, dust, gem) {
         if (dust == air) {
@@ -386,7 +386,7 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        md5(event.recipes.create.milling(outputs, input).processingTime(processingTime), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.recipes.create.milling(outputs, input).processingTime(processingTime), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function create_metal_block_processing(event, material, crushed_ore, ingot, nugget) {
@@ -561,7 +561,7 @@ onEvent('recipes', (event) => {
         var output = dust,
             input = `#forge:gems/${material}`;
 
-        md5(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function immersiveengineering_ingot_crushing(event, material, dust, ingot) {
@@ -573,7 +573,7 @@ onEvent('recipes', (event) => {
             var output = dust,
                 input = `#forge:ingots/${material}`;
 
-            md5(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
+            fallback_id(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
         }
     }
 
@@ -793,8 +793,8 @@ onEvent('recipes', (event) => {
         var output = ingot,
             input = `#forge:ores/${material}`;
 
-        md5(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        md5(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function minecraft_gem_ore_smelting(event, material, ore, gem) {
@@ -813,8 +813,8 @@ onEvent('recipes', (event) => {
         var output = gem,
             input = `#forge:ores/${material}`;
 
-        md5(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        md5(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function minecraft_dust_smelting(event, material, dust, ingot) {
@@ -833,8 +833,8 @@ onEvent('recipes', (event) => {
         var output = ingot,
             input = `#forge:dusts/${material}`;
 
-        md5(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        md5(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function occultism_gem_ore_crushing(event, material, ore, dust, gem, shard) {
@@ -865,7 +865,7 @@ onEvent('recipes', (event) => {
                 return;
         }
 
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'occultism:crushing',
             ingredient: { tag: input },
             result: { item: output, count: count },
@@ -917,7 +917,7 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'occultism:crushing',
             ingredient: { tag: input },
             result: { item: output, count: 1 },
@@ -1004,7 +1004,7 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'pedestals:pedestal_crushing',
             ingredient: {
                 tag: input
@@ -1133,7 +1133,7 @@ onEvent('recipes', (event) => {
             mod: 'thermal',
             type: 'thermal:pulverizer'
         });
-        md5(event.recipes.thermal.pulverizer(output, input), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(event.recipes.thermal.pulverizer(output, input), `${id_prefix}${arguments.callee.name}/`);
     }
 
     function thermal_metal_casting(event, material, ingot, nugget, gear, rod, plate) {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -1,6 +1,6 @@
 //priority: 900
 onEvent('recipes', (event) => {
-    const id_prefix = 'enigmatica:base/unification/unify_dyes/';
+    const id_prefix = 'enigmatica:base/unification/unify_materials/';
 
     materialsToUnify.forEach((material) => {
         let ore = getPreferredItemInTag(Ingredient.of(`#forge:ores/${material}`)).id;

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
@@ -47,7 +47,7 @@ function create_cutting(event, variant, sawDust, treeBark) {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.recipes.create.cutting({
+        fallback_id(event.recipes.create.cutting({
             type: 'create:cutting',
             ingredients: [
                 {
@@ -70,7 +70,7 @@ function create_cutting(event, variant, sawDust, treeBark) {
 }
 
 function immersiveengineering_sawing(event, variant, sawDust, treeBark) {
-    md5(event.recipes.immersiveengineering
+    fallback_id(event.recipes.immersiveengineering
         .sawmill(Item.of(variant.plankBlock, 6), variant.logBlockStripped, [
             {
                 stripping: false,
@@ -79,7 +79,7 @@ function immersiveengineering_sawing(event, variant, sawDust, treeBark) {
         ])
         .energy(800), `enigmatica:base/unification/unify_sawables/${arguments.callee.name}/`);
 
-    md5(event.recipes.immersiveengineering
+    fallback_id(event.recipes.immersiveengineering
         .sawmill(
             Item.of(variant.plankBlock, 6),
             [variant.logBlock, variant.woodBlock],
@@ -133,7 +133,7 @@ function mekanism_sawing(event, variant, sawDust) {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.recipes.mekanism.sawing(Item.of(recipe.output, 6), recipe.input, Item.of(sawDust).chance(0.25)), `enigmatica:base/unification/unify_sawables/${arguments.callee.name}/`);
+        fallback_id(event.recipes.mekanism.sawing(Item.of(recipe.output, 6), recipe.input, Item.of(sawDust).chance(0.25)), `enigmatica:base/unification/unify_sawables/${arguments.callee.name}/`);
     });
 }
 function pedestal_sawing(event, variant) {
@@ -168,7 +168,7 @@ function pedestal_sawing(event, variant) {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.recipes.pedestals.pedestal_sawing({
+        fallback_id(event.recipes.pedestals.pedestal_sawing({
             type: 'pedestals:pedestal_sawing',
             ingredient: {
                 item: recipe.input
@@ -214,7 +214,7 @@ function thermal_sawing(event, variant, sawDust) {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.recipes.thermal
+        fallback_id(event.recipes.thermal
             .sawmill([Item.of(recipe.output, 6), Item.of(sawDust).chance(1.25)], recipe.input)
             .energy(1000), `enigmatica:base/unification/unify_sawables/${arguments.callee.name}/`);
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_stoneworks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_stoneworks.js
@@ -34,7 +34,7 @@ function pedestals_stoneworks(event, material, type) {
             item: material,
             count: 1
         }
-    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}`);
+    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}/`);
 }
 
 function industrialforegoing_stoneworks(event, material, type) {
@@ -56,7 +56,7 @@ function industrialforegoing_stoneworks(event, material, type) {
         waterConsume: waterConsume,
         lavaConsume: lavaConsume,
         type: 'industrialforegoing:stonework_generate'
-    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}`);
+    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}/`);
 }
 
 function thermal_stoneworks(event, material) {
@@ -67,5 +67,5 @@ function thermal_stoneworks(event, material) {
         result: {
             item: material
         }
-    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}`);
+    }), `enigmatica:base/unification/unify_stoneworks/${arguments.callee.name}/`);
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_stoneworks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_stoneworks.js
@@ -25,7 +25,7 @@ function pedestals_stoneworks(event, material, type) {
         recipeType = 'pedestals:pedestal_cobblegensilk';
     }
     //console.log(`Pedestals Recipe for Material: ${material}, Type: ${type}`);
-    md5(event.custom({
+    fallback_id(event.custom({
         type: recipeType,
         ingredient: {
             item: material
@@ -46,7 +46,7 @@ function industrialforegoing_stoneworks(event, material, type) {
         lavaConsume = 0;
     }
 
-    md5(event.custom({
+    fallback_id(event.custom({
         output: {
             item: material,
             count: 1
@@ -60,7 +60,7 @@ function industrialforegoing_stoneworks(event, material, type) {
 }
 
 function thermal_stoneworks(event, material) {
-    md5(event.custom({
+    fallback_id(event.custom({
         type: 'thermal:rock_gen',
         adjacent: 'minecraft:water',
         below: material,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/betterend/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/betterend/alloying.js
@@ -2,13 +2,17 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:expert/betterend/alloying/';
+
     var data = {
         recipes: [
             {
                 inputs: ['#forge:ingots/cobalt', 'thermal:blizz_powder'],
                 output: Item.of('undergarden:froststeel_ingot', 1),
                 experience: 2,
-                smelttime: 300
+                smelttime: 300,
+                id: `${id_prefix}froststeel_ingot`
             }
         ]
     };
@@ -19,6 +23,6 @@ onEvent('recipes', (event) => {
             result: recipe.output,
             experience: recipe.experience,
             smelttime: recipe.smelttime
-        });
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
@@ -99,7 +99,8 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'naturesaura:infused_stone',
                 B: '#bloodmagic:crystals/demon'
-            }
+            },
+            id: 'bloodmagic:dungeon_stone'
         },
         {
             output: 'bloodmagic:alchemicalreactionchamber',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -117,7 +117,7 @@ onEvent('recipes', (event) => {
         if (recipe.id) {
             re.id(recipe.id);
         } else {
-            md5(re, id_prefix);
+            fallback_id(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:expert/botania/mana_infusion/';
+
     const recipes = [
         {
             input: '#forge:ingots/froststeel',
@@ -102,15 +104,20 @@ onEvent('recipes', (event) => {
             output: { item: recipe.output, count: recipe.count },
             mana: recipe.mana
         };
+
         if (recipe.catalyst) {
             constructed_recipe.catalyst = {
                 type: 'block',
                 block: recipe.catalyst
             };
         }
+
         const re = event.custom(constructed_recipe);
+        
         if (recipe.id) {
             re.id(recipe.id);
+        } else {
+            md5(re, id_prefix);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enigmatica/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enigmatica/alloying.js
@@ -2,6 +2,9 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:expert/enigmatica/alloying/';
+
     const recipes = [
         {
             inputs: ['#forge:ingots/compressed_iron', '#forge:gems/quartz'],
@@ -18,23 +21,23 @@ onEvent('recipes', (event) => {
         }
 
         // betterendforge
-        event.custom({
+        md5(event.custom({
             type: 'betterendforge:alloying',
             ingredients: [Ingredient.of(recipe.inputs[0]).toJson(), Ingredient.of(recipe.inputs[1]).toJson()],
             result: recipe.output,
             experience: recipe.experience,
             smelttime: recipe.smelttime
-        });
+        }), id_prefix);
 
         // create
-        event.recipes.create.mixing(recipe.output, recipe.inputs).heated();
+        md5(event.recipes.create.mixing(recipe.output, recipe.inputs).heated(), id_prefix);
 
         // immersiveengineering
-        event.recipes.immersiveengineering.alloy(recipe.output, recipe.inputs[0], recipe.inputs[1]);
-        event.recipes.immersiveengineering.arc_furnace([recipe.output], recipe.inputs[0], [recipe.inputs[1]]);
+        md5(event.recipes.immersiveengineering.alloy(recipe.output, recipe.inputs[0], recipe.inputs[1]), id_prefix);
+        md5(event.recipes.immersiveengineering.arc_furnace([recipe.output], recipe.inputs[0], [recipe.inputs[1]]), id_prefix);
 
         // thermal
-        event.recipes.thermal.smelter([recipe.output], recipe.inputs);
+        md5(event.recipes.thermal.smelter([recipe.output], recipe.inputs), id_prefix);
     };
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enigmatica/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/enigmatica/alloying.js
@@ -21,7 +21,7 @@ onEvent('recipes', (event) => {
         }
 
         // betterendforge
-        md5(event.custom({
+        fallback_id(event.custom({
             type: 'betterendforge:alloying',
             ingredients: [Ingredient.of(recipe.inputs[0]).toJson(), Ingredient.of(recipe.inputs[1]).toJson()],
             result: recipe.output,
@@ -30,14 +30,14 @@ onEvent('recipes', (event) => {
         }), id_prefix);
 
         // create
-        md5(event.recipes.create.mixing(recipe.output, recipe.inputs).heated(), id_prefix);
+        fallback_id(event.recipes.create.mixing(recipe.output, recipe.inputs).heated(), id_prefix);
 
         // immersiveengineering
-        md5(event.recipes.immersiveengineering.alloy(recipe.output, recipe.inputs[0], recipe.inputs[1]), id_prefix);
-        md5(event.recipes.immersiveengineering.arc_furnace([recipe.output], recipe.inputs[0], [recipe.inputs[1]]), id_prefix);
+        fallback_id(event.recipes.immersiveengineering.alloy(recipe.output, recipe.inputs[0], recipe.inputs[1]), id_prefix);
+        fallback_id(event.recipes.immersiveengineering.arc_furnace([recipe.output], recipe.inputs[0], [recipe.inputs[1]]), id_prefix);
 
         // thermal
-        md5(event.recipes.thermal.smelter([recipe.output], recipe.inputs), id_prefix);
+        fallback_id(event.recipes.thermal.smelter([recipe.output], recipe.inputs), id_prefix);
     };
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
@@ -37,7 +37,7 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        md5(event.custom(recipe), id_prefix);
+        fallback_id(event.custom(recipe), id_prefix);
     });
 
     buildWoodVariants.forEach((variant) => {
@@ -57,7 +57,7 @@ onEvent('recipes', (event) => {
             };
             let ingredients = Ingredient.of(recipe.input);
             let result = [Item.of('minecraft:stick', 8)];
-            md5(event.custom({
+            fallback_id(event.custom({
                 type: 'farmersdelight:cutting',
                 ingredients: [ingredients],
                 tool: tool,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -69,7 +69,8 @@ onEvent('recipes', (event) => {
             output: { item: 'mythicbotany:alfsteel_ingot' },
             mana: 1500000,
             fromColor: parseInt('0xFF008D'),
-            toColor: parseInt('0xFF9600')
+            toColor: parseInt('0xFF9600'),
+            id: `${id_prefix}alfsteel_ingot_comb`
         },
         {
             inputs: [
@@ -119,7 +120,7 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        const re = event.custom({
+        event.custom({
             type: 'mythicbotany:infusion',
             group: 'infuser',
             ingredients: recipe.inputs,
@@ -127,9 +128,6 @@ onEvent('recipes', (event) => {
             mana: recipe.mana,
             fromColor: recipe.fromColor,
             toColor: recipe.toColor
-        });
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
@@ -3,7 +3,7 @@ onEvent('recipes', (event) => {
         return;
     }
 
-    // no in the enigmatica namespace for some legacy reason?
+    // not in the enigmatica namespace for some legacy reason?
     const id_prefix = `occultism:spirit_fire/`;
 
     const recipes = [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
@@ -3,31 +3,32 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    // no in the enigmatica namespace for some legacy reason?
+    const id_prefix = `occultism:spirit_fire/`;
+
     const recipes = [
         {
             input: 'ars_nouveau:magic_clay',
-            output: 'bloodmagic:arcaneashes'
+            output: 'bloodmagic:arcaneashes',
+            id: `${id_prefix}arcane_ashes`
         },
         {
             input: 'ars_nouveau:arcane_stone',
             output: 'occultism:otherstone',
-            id: 'otherstone'
+            id: `${id_prefix}otherstone`
         },
         {
             input: '#forge:gems/mana',
             output: 'occultism:spirit_attuned_gem',
-            id: 'spirit_attuned_gem'
+            id: `${id_prefix}spirit_attuned_gem`
         }
     ];
 
     recipes.forEach((recipe) => {
-        let re = event.custom({
+        event.custom({
             type: 'occultism:spirit_fire',
             ingredient: Ingredient.of(recipe.input).toJson(),
             result: Ingredient.of(recipe.output).toJson()
-        });
-        if (recipe.id) {
-            re.id(`occultism:spirit_fire/${recipe.id}`);
-        }
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/block_heat_properties.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/block_heat_properties.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:expert/pneumaticcraft/block_heat_properties/';
+
     /* 
     Fluid Cooling/Heating
     {
@@ -33,12 +35,13 @@ onEvent('recipes', (event) => {
             temperature: 333,
             thermalResistance: 100,
             transformCold: { block: 'immersiveengineering:concrete' },
-            heatCapacity: 10000
+            heatCapacity: 10000,
+            id: `${id_prefix}concrete`
         }
     ];
 
     recipes.forEach((recipe) => {
         recipe.type = 'pneumaticcraft:heat_properties';
-        event.custom(recipe);
+        event.custom(recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/dynamo/compression.js
@@ -2,12 +2,16 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:expert/thermal/compression_fuel/';
+
     var multiplier = 10;
     var data = {
         recipes: [{ input: 'industrialforegoing:biofuel', energy: 1000000 }]
     };
+
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier);
+        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/dynamo/compression.js
@@ -12,6 +12,6 @@ onEvent('recipes', (event) => {
 
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
+        fallback_id(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -81,6 +81,6 @@ function lowerTiers(tiers, tier) {
 function md5(recipe, id_prefix) {
     if (recipe.getId().includes(':kjs_')) {
         recipe.serializeJson(); // without this the hashes *will* collide
-        recipe.id(id_prefix + 'kjs_' + recipe.getUniqueId());
+        recipe.id(id_prefix + 'md5_' + recipe.getUniqueId());
     }
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -81,6 +81,6 @@ function lowerTiers(tiers, tier) {
 function md5(recipe, id_prefix) {
     if (recipe.getId().includes(':kjs_')) {
         recipe.serializeJson(); // without this the hashes *will* collide
-        recipe.id(id_prefix + recipe.getUniqueId());
+        recipe.id(id_prefix + 'kjs_' + recipe.getUniqueId());
     }
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -77,8 +77,8 @@ function lowerTiers(tiers, tier) {
     return tiers.slice(0, tiers.indexOf(tier));
 }
 
-// transplant the md5 from `<type's mod>:kjs_<md5>` onto the supplied prefix
-function md5(recipe, id_prefix) {
+// transplant the md5 from `<type's mod>:kjs_<hash>` onto the supplied prefix
+function fallback_id(recipe, id_prefix) {
     if (recipe.getId().includes(':kjs_')) {
         recipe.serializeJson(); // without this the hashes *will* collide
         recipe.id(id_prefix + 'md5_' + recipe.getUniqueId());

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/recipes/shapeless/';
+
     const recipes = [
         {
             output: 'mekanism:hdpe_sheet',
@@ -11,7 +13,8 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'quark:root',
-            inputs: ['minecraft:vine', '#forge:dyes/brown']
+            inputs: ['minecraft:vine', '#forge:dyes/brown'],
+            id: `${id_prefix}quark_root`
         },
         {
             output: Item.of('refinedstorage:quartz_enriched_iron', 4),
@@ -21,8 +24,6 @@ onEvent('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            ? event.shapeless(recipe.output, recipe.inputs).id(recipe.id)
-            : event.shapeless(recipe.output, recipe.inputs);
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
@@ -2,12 +2,26 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:normal/astralsorcery/block_transmutation/';
+
     var data = {
         recipes: [
-            { inputTag: '#forge:ores/iron', output: 'astralsorcery:starmetal_ore', starlight: 100 },
-            { inputTag: '#forge:workbenches', output: 'astralsorcery:altar_discovery', starlight: 60 }
+            {
+                inputTag: '#forge:ores/iron',
+                output: 'astralsorcery:starmetal_ore',
+                starlight: 100,
+                id: `${id_prefix}starmetal_ore`
+            },
+            { 
+                inputTag: '#forge:workbenches',
+                output: 'astralsorcery:altar_discovery',
+                starlight: 60,
+                id: `${id_prefix}luminous_crafting_table`
+            }
         ]
     };
+
     data.recipes.forEach((recipe) => {
         Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
             if (!input.id.includes('chunk')) {
@@ -20,7 +34,7 @@ onEvent('recipes', (event) => {
                         block: recipe.output
                     },
                     starlight: recipe.starlight
-                });
+                }).id(recipe.id);
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
@@ -11,13 +11,13 @@ onEvent('recipes', (event) => {
                 inputTag: '#forge:ores/iron',
                 output: 'astralsorcery:starmetal_ore',
                 starlight: 100,
-                id: `${id_prefix}starmetal_ore`
+                id: `${id_prefix}starmetal_ore_from_`
             },
             { 
                 inputTag: '#forge:workbenches',
                 output: 'astralsorcery:altar_discovery',
                 starlight: 60,
-                id: `${id_prefix}luminous_crafting_table`
+                id: `${id_prefix}luminous_crafting_table_from_`
             }
         ]
     };
@@ -25,7 +25,7 @@ onEvent('recipes', (event) => {
     data.recipes.forEach((recipe) => {
         Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
             if (!input.id.includes('chunk')) {
-                event.custom({
+                md5(event.custom({
                     type: 'astralsorcery:block_transmutation',
                     input: {
                         block: input.id
@@ -34,7 +34,7 @@ onEvent('recipes', (event) => {
                         block: recipe.output
                     },
                     starlight: recipe.starlight
-                }).id(recipe.id);
+                }), id_prefix);
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
@@ -34,7 +34,7 @@ onEvent('recipes', (event) => {
                         block: recipe.output
                     },
                     starlight: recipe.starlight
-                }), id_prefix);
+                }), recipe.id);
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
@@ -25,7 +25,7 @@ onEvent('recipes', (event) => {
     data.recipes.forEach((recipe) => {
         Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
             if (!input.id.includes('chunk')) {
-                md5(event.custom({
+                fallback_id(event.custom({
                     type: 'astralsorcery:block_transmutation',
                     input: {
                         block: input.id

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/shaped.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/bloodmagic/shaped/';
+
     const recipes = [
         {
             output: Item.of('bloodmagic:dungeon_stone', 8),
@@ -10,15 +12,12 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:stone',
                 B: '#bloodmagic:crystals/demon'
-            }
+            },
+            id: `${id_prefix}dungeon_stone`
         }
     ];
 
     recipes.forEach((recipe) => {
-        if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
-        } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
-        }
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/mana_infusion.js
@@ -2,18 +2,23 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:normal/botania/mana_infusion/';
+
     const recipes = [
         {
             input: 'resourcefulbees:mana_honeycomb',
             output: 'botania:manasteel_ingot',
             count: 1,
-            mana: 2000
+            mana: 2000,
+            id: `${id_prefix}manasteel_ingot`
         },
         {
             input: 'resourcefulbees:mana_honeycomb_block',
             output: 'botania:manasteel_block',
             count: 1,
-            mana: 19000
+            mana: 19000,
+            id: `${id_prefix}manasteel_block`
         }
     ];
 
@@ -24,15 +29,14 @@ onEvent('recipes', (event) => {
             output: { item: recipe.output, count: recipe.count },
             mana: recipe.mana
         };
+        
         if (recipe.catalyst) {
             constructed_recipe.catalyst = {
                 type: 'block',
                 block: recipe.catalyst
             };
         }
-        const re = event.custom(constructed_recipe);
-        if (recipe.id) {
-            re.id(recipe.id);
-        }
+
+        event.custom(constructed_recipe).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/eidolon/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/eidolon/shapeless.js
@@ -3,14 +3,17 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/eidolon/shapeless/';
+
     const recipes = [
         {
             output: 'eidolon:candle',
-            inputs: ['occultism:candle_white']
+            inputs: ['occultism:candle_white'],
+            id: `${id_prefix}candle`
         }
     ];
 
     recipes.forEach((recipe) => {
-        event.shapeless(recipe.output, recipe.inputs);
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
@@ -3,13 +3,16 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/mekanism/metallurgic_infusing/';
+
     var data = {
         recipes: [
             {
                 output: Item.of('compactmachines:wall', 32),
                 inputItem: '#forge:storage_blocks/ender',
                 infusionInput: 'mekanism:refined_obsidian',
-                infusionAmount: 80
+                infusionAmount: 80,
+                id: `${id_prefix}compactmachines_wall`
             }
         ]
     };
@@ -20,6 +23,6 @@ onEvent('recipes', (event) => {
             recipe.inputItem,
             recipe.infusionInput,
             recipe.infusionAmount
-        );
+        ).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/minecraft/stonecutter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/minecraft/stonecutter.js
@@ -2,5 +2,8 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
-    event.stonecutting('atum:crystal_glass', 'minecraft:glass');
+
+    const id_prefix = 'enigmatica:normal/minecraft/stonecutter/';
+
+    event.stonecutting('atum:crystal_glass', 'minecraft:glass').id(`${id_prefix}glass_from_crystal_glass`);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
@@ -2,6 +2,9 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
+
+    // todo: id_prefix
+
     const recipes = [
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/naturesaura/altar/';
+
     var data = {
         recipes: [
             {
@@ -10,7 +12,8 @@ onEvent('recipes', (event) => {
                 output: Item.of('compactmachines:wall', 32),
                 aura_type: 'naturesaura:overworld',
                 aura: 15000,
-                time: 100
+                time: 100,
+                id: `${id_prefix}compactmachines_wall`
             }
         ]
     };
@@ -23,6 +26,6 @@ onEvent('recipes', (event) => {
             aura_type: recipe.aura_type,
             aura: recipe.aura,
             time: recipe.time
-        });
+        }).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/shapeless.js
@@ -3,15 +3,17 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/occultism/shapeless/';
+
     const recipes = [
         {
             output: 'occultism:candle_white',
             inputs: ['#quark:candles'],
+            id: `${id_prefix}candle_white`
         }
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            event.shapeless(recipe.output, recipe.inputs);
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shaped.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/quark/shaped/';
+
     const recipes = [
         {
             output: Item.of('quark:white_candle', 4),
@@ -10,15 +12,12 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#enigmatica:candle_materials',
                 B: '#forge:string'
-            }
+            },
+            id: `${id_prefix}white_candle`
         }
     ];
 
     recipes.forEach((recipe) => {
-        if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
-        } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
-        }
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shapeless.js
@@ -3,19 +3,21 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/quark/shapeless/';
+
     const recipes = [
         {
             output: 'quark:white_candle',
             inputs: ['#quark:candles', 'minecraft:white_dye'],
+            id: `${id_prefix}dye_cancle_white`
         },
         {   output: 'quark:white_candle',
             inputs: 'eidolon:candle',
-
+            id: `${id_prefix}white_candle`
         }
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            event.shapeless(recipe.output, recipe.inputs);
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/dynamo/compression.js
@@ -12,6 +12,6 @@ onEvent('recipes', (event) => {
 
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
+        fallback_id(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/dynamo/compression.js
@@ -2,12 +2,16 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
+
+    const id_prefix = 'enigmatica:normal/thermal/compression_fuel/';
+
     var multiplier = 10;
     var data = {
         recipes: [{ input: 'industrialforegoing:biofuel', energy: 100000 }]
     };
+
     data.recipes.forEach((recipe) => {
         //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
-        event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier);
+        md5(event.recipes.thermal.compression_fuel(Fluid.of(recipe.input, 1000)).energy(recipe.energy * multiplier), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
@@ -23,6 +23,6 @@ onEvent('recipes', (event) => {
     };
 
     data.recipes.forEach((recipe) => {
-        md5(event.recipes.thermal.smelter(recipe.outputs, recipe.inputs), id_prefix);
+        fallback_id(event.recipes.thermal.smelter(recipe.outputs, recipe.inputs), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/thermal/smelter/';
+
     var data = {
         recipes: [
             {
@@ -21,6 +23,6 @@ onEvent('recipes', (event) => {
     };
 
     data.recipes.forEach((recipe) => {
-        event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+        md5(event.recipes.thermal.smelter(recipe.outputs, recipe.inputs), id_prefix);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/torchmaster/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/torchmaster/shaped.js
@@ -3,6 +3,8 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:normal/torchmaster/shaped/';
+
     const recipes = [
         {
             output: 'torchmaster:megatorch',
@@ -12,7 +14,8 @@ onEvent('recipes', (event) => {
                 B: '#enigmatica:crafting_materials/diamond',
                 C: '#minecraft:logs',
                 D: '#forge:storage_blocks/gold'
-            }
+            },
+            id: `${id_prefix}megatorch`
         },
         {
             output: 'torchmaster:feral_flare_lantern',
@@ -21,15 +24,12 @@ onEvent('recipes', (event) => {
                 A: '#forge:ingots/gold',
                 B: '#forge:glass',
                 C: '#forge:storage_blocks/glowstone'
-            }
+            },
+            id: `${id_prefix}feral_flare_lantern`
         }
     ];
 
     recipes.forEach((recipe) => {
-        if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
-        } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
-        }
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
     });
 });


### PR DESCRIPTION
The `:kjs_` recipe ids are hard to track down, this pull request will get rid of all of them.

Using the CI script i have tracked down all recipes that lack a custom id, at first i tried to fix all of them by hand but that proved pretty much impossible due to avoiding duplicate name conflicts in unification scripts, as well as deciding a name.

In this pull request the easy/small ones are given a prefix & name by hand, but for the larger bulk i have introduced a helper function called `md5`, which basically takes the part from after `:kjs_`and puts the supplied `id_prefix` in front of it.

This will help to find where the random ids are defined, but avoids the effort required for coming up with naming schemes.

Therefore this is a compromise, ideally we'd have all recipes named by hand, but these are at least a little easier to maintain since the id points to the right file (& function) responsible for adding the recipe.

Once this is merged one simply has to search for `md5` in the kubejs scripts to find which recipes still require a manual name, this pull request is not the end goal but merely a stepping stone.

Before i'll turn draft mode off i'll go over it using the github checkboxes to clean it up a little more, but after that it should be good to go.

I have checked that no added recipes got lost by comparing the `added` recipes file of the ci of the base & pull branch:
```
const fs = require('fs');

let fork = JSON.parse(fs.readFileSync('added_fork.json'));
let origin = JSON.parse(fs.readFileSync('added_origin.json'));

console.log([
  Object.entries(fork).length,
  Object.entries(origin).length,
]);
```
Strangely this returns `[ 20403, 20402 ]`, so no recipes got lost but one slipped in, should be no cause for concern. 🤔 
![Screen Shot 2022-05-17 at 11 55 21](https://user-images.githubusercontent.com/3179271/168784495-6fda73e7-af7c-45dc-8fd5-c9fd81e1ba75.png)

