### PR TITLE
Show notice for expired `//todo remove in #.#.#`’s

### DIFF
--- a/.github/actions/ci/kubejs-todo-remove.js
+++ b/.github/actions/ci/kubejs-todo-remove.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const { execSync } = require("child_process");
+
+//
+
+let modpack_version = fs.readFileSync('./automation/settings.ps1').toString().match(/\$MODPACK_VERSION = "(\d\.\d\.\d)"/)[1];
+
+let to_remove = 0;
+let not_empty = 0;
+
+//
+
+/* https://github.com/substack/semver-compare */
+function semver_compare(a, b) {
+  var pa = a.split('.');
+  var pb = b.split('.');
+  for (var i = 0; i < 3; i++) {
+      var na = Number(pa[i]);
+      var nb = Number(pb[i]);
+      if (na > nb) return 1;
+      if (nb > na) return -1;
+      if (!isNaN(na) && isNaN(nb)) return 1;
+      if (isNaN(na) && !isNaN(nb)) return -1;
+  }
+  return 0;
+}
+
+function handle_directory(node) {
+  switch(node.type) {
+    case "directory":
+      node.contents.forEach(content => {
+        content.name = `${node.name}/${content.name}`;
+        handle_directory(content);
+      });
+      break;
+    case "file":
+      handle_file(node);
+    break;
+  }
+}
+
+function handle_file(file) {
+  const lines = fs.readFileSync(file.name).toString().split('\n');
+  
+  if (lines[0].toLowerCase().includes('remove in')) {
+    let version = lines[0].match(/\d\.\d\.\d/)[0];
+    if (semver_compare(modpack_version, version) == 1) {
+      console.log(file.name);
+      to_remove++;
+      if (lines.length > 2) not_empty++;
+    }
+  }
+}
+
+//
+
+const tree = JSON.parse(execSync("tree -J -P '*.js' ./kubejs").toString())[0];
+handle_directory(tree);
+
+if(to_remove) {
+  let notice = `::notice::${to_remove} kubejs files can be safely deleted now.`;
+
+  if(not_empty) {
+    notice += ` (of which ${not_empty} are not empty)`;
+  }
+
+  console.log(notice);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,11 @@ jobs:
                     ./logs
                     ./crash-reports
                     ./kubejs/exported/recipes
+    kubejs:
+        runs-on: ubuntu-latest
+        timeout-minutes: 1
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+
+            - run: node .github/actions/ci/kubejs-todo-remove.js 


### PR DESCRIPTION
This is different territory than my other CI related pull requests, basically scripts that will warn about inconsistencies, which after their initial run their usefulness greatly reduces, for example this pull request now shows this notice:
![Screen Shot 2022-05-17 at 14 47 24](https://user-images.githubusercontent.com/3179271/168814709-969bb912-1158-462d-a53b-9471bccf1328.png)

But after all those files flagged for removal have been removed, it will obviously not output a list of files anymore:
![Screen Shot 2022-05-17 at 14 47 45](https://user-images.githubusercontent.com/3179271/168814876-0b6b92f2-178c-4b6e-a30d-634447ea3c63.png)

There are a few more similar kubejs file check scripts in my pipeline, but lets first see how this one is received. 🤔 

(i have plans to make it modular & use npm to import packages to clean it up a bit, but that's for when we have multiples)
