### PR TITLE
Polyfill `instancesync` & `update-server` for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
               run: |
                   cp ./automation/settings.cfg ./settings.cfg
                   cp ./automation/start-automated-server.sh ./start-automated-server.sh
+                  pwsh ./automation/remove-client-mods.ps1
 
             - name: Setting eula to true
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
                   node .github/actions/ci/packmode.js ${{ matrix.packmode }} > mode.json
                   cat mode.json
 
-            - name: bash ./InstanceSyncSetup.sh
+            - name: cd automation && bash ./InstanceSyncSetup.sh
               run: java -jar InstanceSync.jar
-            - name: pwsh ./update-server.ps1
+            - name: cd automation && pwsh ./update-server.ps1
               run: |
                   cp ./automation/settings.cfg ./settings.cfg
                   cp ./automation/start-automated-server.sh ./start-automated-server.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
                   node .github/actions/ci/packmode.js ${{ matrix.packmode }} > mode.json
                   cat mode.json
 
-            - run: bash ./InstanceSyncSetup.sh
-              working-directory: ./automation
-            - run: pwsh ./update-server.ps1 ${{ github.ref_name }} world backups $true $false
-              working-directory: ./automation
+            - name: bash ./InstanceSyncSetup.sh
+              run: java -jar InstanceSync.jar
+            - name: pwsh ./update-server.ps1
+              run: |
+                  cp ./automation/settings.cfg ./settings.cfg
+                  cp ./automation/start-automated-server.sh ./start-automated-server.sh
 
             - name: Setting eula to true
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,9 @@ jobs:
           node .github/actions/ci/packmode.js ${{ matrix.packmode }} > mode.json
           cat mode.json
 
-      - name: cd automation && bash ./InstanceSyncSetup.sh
-        run: java -jar InstanceSync.jar
-      - name: cd automation && pwsh ./update-server.ps1
+      - name: Install server
         run: |
+          java -jar InstanceSync.jar
           cp ./automation/settings.cfg ./settings.cfg
           cp ./automation/start-automated-server.sh ./start-automated-server.sh
           pwsh ./automation/remove-client-mods.ps1


### PR DESCRIPTION
After taking a closer look at what goes wrong if you don't call `update-server.ps1` it basically boils down to just `settings.cfg` and `start-automated-server.sh` not being able to find one another:
```
> Run node .github/actions/ci/start-server.js bash ./automation/start-automated-server.sh
./automation/start-automated-server.sh: line 161: settings.cfg: No such file or directory
```
Apart from copying those files the entire rest of the file seems to only do stuff related to detecting & pulling changes from a remote git repository, but during ci the changes are already pulled/checked-out, so we can bypass it just fine.

Since `update-server.ps1` pulled it needed the `instancesync setup` to hook up some git events, but we don't need that anymore since we're only pulling once + a manual `instancesync` afterwards, so that has been simplified as well.