### PR TITLE
Eliminate material unification rod recipe race condition

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -99,7 +99,7 @@ onEvent('recipes', (event) => {
         event.recipes.thermal
             .press(rod, [input, mold])
             .energy(2400)
-            .id(`kubejs:immersiveengineering_metal_press_${material}_rod`);
+            .id(`thermal:machine/press/press_${material}_ingot_to_rod`);
 
         event.recipes.immersiveengineering
             .metal_press(`4x ${rod}`, `4x ${input}`, mold)


### PR DESCRIPTION
This is causing annoying race conditions in something i am trying to test:
<img width="427" alt="Screen Shot 2022-05-18 at 13 21 25" src="https://user-images.githubusercontent.com/3179271/169027402-6c2fd289-12b1-4313-859e-11275cfc49c6.png">
Therefore i changed the format to the one found on line 64 of that same file.
(It appears both recipes work since the recipe map is keyed by type first, but imo they still should not collide)
![Screen Shot 2022-05-18 at 13 53 29](https://user-images.githubusercontent.com/3179271/169032823-08952c12-cead-409e-8e5a-b75e6264b4d5.png)
![Screen Shot 2022-05-18 at 13 53 38](https://user-images.githubusercontent.com/3179271/169032840-a84b4668-1705-44dc-b44a-86de2f91c970.png)
(i did notice this when i was working on naming all of them, but it didn't get in my way at the time so i ignored it until i have time to weed out duplicates, but rn this one is simply getting in my way)
