### PR TITLE
Fix some more kubejs inconsistencies by observing duplicate recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/filling.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/filling.js
@@ -23,19 +23,19 @@ onEvent('recipes', (event) => {
             input: 'minecraft:glass_bottle',
             fluid: Fluid.of('industrialforegoing:essence', 250),
             output: 'minecraft:experience_bottle',
-            id: `${id_prefix}experience_bottle`
+            id: `${id_prefix}experience_bottle_if`
         },
         {
             input: 'minecraft:glass_bottle',
             fluid: Fluid.of('pneumaticcraft:memory_essence', 250),
             output: 'minecraft:experience_bottle',
-            id: `${id_prefix}experience_bottle`
+            id: `${id_prefix}experience_bottle_pnc`
         },
         {
             input: 'minecraft:glass_bottle',
             fluid: Fluid.of('cofh_core:experience', 250),
             output: 'minecraft:experience_bottle',
-            id: `${id_prefix}experience_bottle`
+            id: `${id_prefix}experience_bottle_cofh`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/smelting.js
@@ -47,7 +47,7 @@ onEvent('recipes', (event) => {
             input: Item.of('dustrial_decor:rusty_iron_ingot'),
             output: Item.of('#forge:ingots/iron'),
             xp: 0.1,
-            id: `${id_prefix}iron_nugget_from_iron_knife`
+            id: `${id_prefix}iron_nugget_from_rusty_iron_ingot`
         },
         {
             input: Item.of('dustrial_decor:rusty_iron_nugget'),
@@ -59,7 +59,7 @@ onEvent('recipes', (event) => {
             input: '#forge:dusts/netherite',
             output: Item.of('#forge:ingots/netherite'),
             xp: 0.1,
-            id: `${id_prefix}iron_ingot_from_rusty_iron_ingot`
+            id: `${id_prefix}netherite_ingot_from_netherite_dust`
         },
         {
             input: 'aquaculture:tin_can',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
@@ -583,7 +583,7 @@ onEvent('recipes', (event) => {
                 B: '#forge:ingots/nebu',
                 C: '#atum:godshards'
             },
-            id: `${id_prefix}raw_gloomper_meat`
+            id: `${id_prefix}godforged_block`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -2025,12 +2025,6 @@ const cropRegistry = [
                 substrate: 'water'
             },
             {
-                seed: 'byg:cattail',
-                render: 'byg:cattail',
-                plant: 'byg:cattail',
-                substrate: 'water'
-            },
-            {
                 seed: 'projectvibrantjourneys:sea_oats',
                 render: 'projectvibrantjourneys:sea_oats',
                 plant: 'projectvibrantjourneys:sea_oats',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -1767,12 +1767,6 @@ const cropRegistry = [
                 substrate: 'end_stone'
             },
             {
-                seed: 'byg:shulkren_moss_blanket',
-                render: 'byg:shulkren_moss_blanket',
-                plant: 'byg:shulkren_moss_blanket',
-                substrate: 'end_stone'
-            },
-            {
                 seed: 'byg:sythian_roots',
                 render: 'byg:sythian_roots',
                 plant: 'byg:sythian_roots',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -1869,12 +1869,6 @@ const cropRegistry = [
                 substrate: 'deepturf'
             },
             {
-                seed: 'undergarden:ashen_deepturf',
-                render: 'undergarden:ashen_deepturf',
-                plant: 'undergarden:ashen_deepturf',
-                substrate: 'deepturf'
-            },
-            {
                 seed: 'undergarden:deepturf',
                 render: 'undergarden:deepturf',
                 plant: 'undergarden:deepturf',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/materials.js
@@ -28,7 +28,6 @@ const materialsToUnify = [
     'obsidian',
     'ender',
     'fluix',
-    'saltpeter',
     'fluorite',
     'invar',
     'signalum',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/shapeless.js
@@ -7,12 +7,12 @@ onEvent('recipes', (event) => {
         {
             output: 'industrialforegoing:fluid_collector',
             inputs: ['industrialforegoing:fluid_placer'],
-            id: 'industrialforegoing:fluid_collector'
+            id: `${id_prefix}fluid_collector`
         },
         {
             output: 'industrialforegoing:fluid_placer',
             inputs: ['industrialforegoing:fluid_collector'],
-            id: `${id_prefix}fluid_placer_alt`
+            id: `${id_prefix}fluid_placer`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -465,7 +465,7 @@ onEvent('recipes', (event) => {
             sapling: 'architects_palette:twisted_sapling',
             output: 'naturesaura:shockwave_creator',
             time: 4 * time_multiplier,
-            id: 'naturesaura:shockwave_creator'
+            id: 'naturesaura:shockwave_creator' // todo: this id gets an altered_recipe_indicator, why reuse it here?
         },
         {
             ingredients: [

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
@@ -151,7 +151,7 @@ onEvent('recipes', (event) => {
         event.recipes.thermal
             .press(Item.of(output, 2), [input, mold])
             .energy(2400)
-            .id(`${id_prefix}immersiveengineering_metal_press_${material}_wire`);
+            .id(`thermal:machine/press/press_${material}_ingot_to_wire`);
 
         event.recipes.immersiveengineering
             .metal_press(Item.of(output, 2), input, mold)


### PR DESCRIPTION
before:
![Screen Shot 2022-05-19 at 10 06 51](https://user-images.githubusercontent.com/3179271/169244706-8c7e69ce-0170-4753-92b2-b42155a4a422.png)

after:
![Screen Shot 2022-05-19 at 10 07 41](https://user-images.githubusercontent.com/3179271/169244761-a7bd305f-eed5-41c0-9961-43d50296787c.png)

the bulk of the other recipe id overrides can be attributed to wood types being cast to another, like avocado to oak.
