### PR TITLE
Include downloadUrl in future manifest files

### DIFF
--- a/automation/modpack-uploader.ps1
+++ b/automation/modpack-uploader.ps1
@@ -136,9 +136,10 @@ function New-ManifestJson {
     $mods = [System.Collections.ArrayList]@()
     foreach ($addon in $minecraftInstanceJson.installedAddons) {
         $mods.Add(@{
-                required  = $true
-                projectID = $addon.addonID
-                fileID    = $addon.installedFile.id
+                required    = $true
+                projectID   = $addon.addonID
+                fileID      = $addon.installedFile.id
+                downloadUrl = $addon.installedFile.downloadUrl
             }) > $null
     }
 

--- a/server_files/start-server.bat
+++ b/server_files/start-server.bat
@@ -12,16 +12,16 @@ CD "%~dp0" >nul 2>&1
 
 :CHECK
 REM Check if serverstarter JAR is already downloaded
-IF NOT EXIST "%cd%\serverstarter-2.2.0.jar" (
+IF NOT EXIST "%cd%\serverstarter-2.4.0.jar" (
 	ECHO serverstarter binary not found, downloading serverstarter...
-	%SYSTEMROOT%\SYSTEM32\bitsadmin.exe /rawreturn /nowrap /transfer starter /dynamic /download /priority foreground https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.2.0.jar "%cd%\serverstarter-2.2.0.jar"
+	%SYSTEMROOT%\SYSTEM32\bitsadmin.exe /rawreturn /nowrap /transfer starter /dynamic /download /priority foreground https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.4.0/serverstarter-2.4.0.jar "%cd%\serverstarter-2.4.0.jar"
    GOTO MAIN
 ) ELSE (
    GOTO MAIN
 )
 
 :MAIN
-java -jar serverstarter-2.2.0.jar
+java -jar serverstarter-2.4.0.jar
 GOTO EOF
 
 :EOF

--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -17,7 +17,7 @@ if [ -f serverstarter-2.2.0.jar ]; then
     fi
     exit 0
 else
-    export URL="https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.2.0.jar"
+    export URL="https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.4.0/serverstarter-2.4.0.jar"
 fi
 echo $URL
 if command -v wget >>/dev/null; then

--- a/server_files_expert/start-server.bat
+++ b/server_files_expert/start-server.bat
@@ -12,16 +12,16 @@ CD "%~dp0" >nul 2>&1
 
 :CHECK
 REM Check if serverstarter JAR is already downloaded
-IF NOT EXIST "%cd%\serverstarter-2.2.0.jar" (
+IF NOT EXIST "%cd%\serverstarter-2.4.0.jar" (
 	ECHO serverstarter binary not found, downloading serverstarter...
-	%SYSTEMROOT%\SYSTEM32\bitsadmin.exe /rawreturn /nowrap /transfer starter /dynamic /download /priority foreground https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.2.0.jar "%cd%\serverstarter-2.2.0.jar"
+	%SYSTEMROOT%\SYSTEM32\bitsadmin.exe /rawreturn /nowrap /transfer starter /dynamic /download /priority foreground https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.4.0.jar "%cd%\serverstarter-2.4.0.jar"
    GOTO MAIN
 ) ELSE (
    GOTO MAIN
 )
 
 :MAIN
-java -jar serverstarter-2.2.0.jar
+java -jar serverstarter-2.4.0.jar
 GOTO EOF
 
 :EOF

--- a/server_files_expert/start-server.sh
+++ b/server_files_expert/start-server.sh
@@ -7,9 +7,9 @@ if [[ $(cat server-setup-config.yaml | grep 'ramDisk:' | awk 'BEGIN {FS=":"}{pri
     sudo mount -t tmpfs -o size=2G tmpfs "$SAVE_DIR"
     DO_RAMDISK=1
 fi
-if [ -f serverstarter-2.2.0.jar ]; then
-    echo "Skipping download. Using existing serverstarter-2.2.0.jar"
-    java -jar serverstarter-2.2.0.jar
+if [ -f serverstarter-2.4.0.jar ]; then
+    echo "Skipping download. Using existing serverstarter-2.4.0.jar"
+    java -jar serverstarter-2.4.0.jar
     if [[ $DO_RAMDISK -eq 1 ]]; then
         sudo umount "$SAVE_DIR"
         rm -rf "$SAVE_DIR"
@@ -17,21 +17,21 @@ if [ -f serverstarter-2.2.0.jar ]; then
     fi
     exit 0
 else
-    export URL="https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.2.0.jar"
+    export URL="https://github.com/EnigmaticaModpacks/ServerStarter/releases/download/v2.2.0/serverstarter-2.4.0.jar"
 fi
 echo $URL
 if command -v wget >>/dev/null; then
     echo "DEBUG: (wget) Downloading ${URL}"
-    wget -O serverstarter-2.2.0.jar "${URL}"
+    wget -O serverstarter-2.4.0.jar "${URL}"
 else
     if command -v curl >>/dev/null; then
         echo "DEBUG: (curl) Downloading ${URL}"
-        curl -L -o serverstarter-2.2.0.jar "${URL}"
+        curl -L -o serverstarter-2.4.0.jar "${URL}"
     else
         echo "Neither wget or curl were found on your system. Please install one and try again"
     fi
 fi
-java -jar serverstarter-2.2.0.jar
+java -jar serverstarter-2.4.0.jar
 if [[ $DO_RAMDISK -eq 1 ]]; then
     sudo umount "$SAVE_DIR"
     rm -rf "$SAVE_DIR"


### PR DESCRIPTION
The serverstarter is currently broken since the api behind it is down, but since instancesync still worked i decided to dig a little deeper, and noticed that the starter only used the api to resolve the download links, but they are already present in the `minecraftinstance.json` niller uses to generate the server files, this pull requests adds an extra property to the json.

Naturally this means only manifests created with this additional property will benefit from it, and not any normal curse ones.

It (obviously) requires changes to the bundled server starter: https://github.com/EnigmaticaModpacks/ServerStarter/pull/3