### PR TITLE
[Expert] Fix typo preventing alternate assembly controller recipe from showing in game.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
@@ -222,13 +222,13 @@ onEvent('recipes', (event) => {
             input: { item: 'kubejs:assembly_controller_assembly', count: 1 },
             output: { item: 'pneumaticcraft:assembly_controller', count: 1 },
             program: 'laser',
-            id: `${id_prefix}asssembly_controller_alternate`
+            id: `${id_prefix}assembly_controller_alternate`
         },
         {
             input: { tag: 'forge:storage_blocks/brass', count: 1 },
             output: { item: 'create:furnace_engine', count: 1 },
             program: 'drill',
-            id: `${id_prefix}assembly_controller_assembly`
+            id: `${id_prefix}furnace_engine_alternate`
         },
         {
             input: { tag: 'forge:ingots/brass', count: 32 },


### PR DESCRIPTION
[Expert] Fix typo preventing alternate assembly controller recipe from showing in game.

Resolves: #4890