### PR TITLE
Update External Storage quests to clarify they can be used for both Items and Fluids

### DIFF
--- a/config/ftbquests/quests/chapters/refined_storage.snbt
+++ b/config/ftbquests/quests/chapters/refined_storage.snbt
@@ -260,7 +260,11 @@
 			x: -1.0d
 			y: 3.5d
 			subtitle: "When disks aren't enough"
-			description: ["If you set up an External Storage part facing a normal inventory (e.g. a chest), that inventory will be treated as part of the network, and its contents can be accessed as though they were on storage drives."]
+			description: [
+				"If you set up an External Storage part facing a normal inventory (e.g. a chest), that inventory will be treated as part of the network, and its contents can be accessed as though they were on storage drives."
+				""
+				"Incidentally, this can also work with fluids by attaching it to any sort of tank and setting the type to fluids. "
+			]
 			dependencies: ["0000000000000256"]
 			id: "0000000000000262"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -1370,7 +1370,9 @@
 			x: 1.0d
 			y: -3.5d
 			description: [
-				"The External Storage can be used to provide RS with access to your fluids stored in other tanks. Attach it to the tank as you would with an item inventory, but then in it's UI, click the \"Type\" button on the left, 2nd from the top, to change it to fluids mode."
+				"With its normal settings, External Storage works with items. However, it too can be used to provide RS with access to fluids stored in other tanks. "
+				""
+				"Attach it to the tank as you would with an item inventory, then in its UI, click the \"Type\" button on the left to change it to fluids mode."
 				""
 				"To filter it, just as with items, you can drag a fluid into the slots directly from JEI (the square texture version, not a filled bucket)"
 			]


### PR DESCRIPTION
Update External Storage quests to clarify they can be used for both Items and Fluids. Resolves #4809