### PR TITLE
Many fixes for packing and unpacking with Thermal and Immersive Engineering

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -74,6 +74,8 @@ onEvent('recipes', (event) => {
 
         'architects_palette:smelting/charcoal_block_from_logs_that_burn_smoking',
 
+        'ars_nouveau:mana_gem_2',
+
         'astralsorcery:infuser/gold_ore',
         'astralsorcery:shaped/marble/marble_slab',
 
@@ -168,6 +170,7 @@ onEvent('recipes', (event) => {
         'immersivepetroleum:distillationtower/oilcracking',
         'immersiveengineering:crafting/coal_coke_to_coke',
         //'immersiveengineering:crafting/ingot_copper_to_storage_copper',
+        'immersiveengineering:crafting/coke_to_coal_coke',
 
         'materialis:smeltery/melting/metal/starmetal/dust',
         /materialis:armor\/building\/exosuit/,
@@ -236,6 +239,7 @@ onEvent('recipes', (event) => {
         'thermal:smelting/cured_rubber_from_smelting',
         'thermal:storage/sulfur_block',
         'thermal:gunpowder_4',
+        'thermal:machine/press/unpacking/press_coal_coke_unpacking',
 
         'pneumaticcraft:one_probe_crafting',
 
@@ -246,6 +250,7 @@ onEvent('recipes', (event) => {
         'projectvibrantjourneys:seashells',
 
         'quark:building/crafting/compressed/gunpowder_sack',
+        'quark:building/crafting/compressed/charcoal_block_compress',
 
         'simplefarming:candy',
         'simplefarming:raw_chicken_wings',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -84,6 +84,7 @@ onEvent('recipes', (event) => {
         'atum:pumpkin_pie',
 
         'betterendforge:gunpowder_from_sulphur',
+        'betterendforge:ender_block',
 
         'bloodmagic:smelting/ingot_netherite_scrap',
         'bloodmagic:alchemytable/gunpowder',
@@ -240,6 +241,12 @@ onEvent('recipes', (event) => {
         'thermal:storage/sulfur_block',
         'thermal:gunpowder_4',
         'thermal:machine/press/unpacking/press_coal_coke_unpacking',
+        'thermal:machine/press/packing2x2/press_clay_packing',
+        'thermal:machine/press/unpacking/press_clay_unpacking',
+        'thermal:machine/press/packing2x2/press_quartz_packing',
+        'thermal:machine/press/unpacking/press_quartz_unpacking',
+        'thermal:machine/press/packing2x2/press_slag_packing',
+        'thermal:machine/press/unpacking/press_slag_unpacking',
 
         'pneumaticcraft:one_probe_crafting',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -43,6 +43,26 @@ onEvent('recipes', (event) => {
             replaceTarget: { id: 'minecraft:grindstone' },
             toReplace: 'minecraft:stone_slab',
             replaceWith: '#enigmatica:crafting_slabs'
+        },
+        {
+            replaceTarget: {},
+            toReplace: 'emendatusenigmatica:coke_block',
+            replaceWith: '#forge:storage_blocks/coke'
+        },
+        {
+            replaceTarget: {},
+            toReplace: 'emendatusenigmatica:arcane_block',
+            replaceWith: '#forge:storage_blocks/mana'
+        },
+        {
+            replaceTarget: {},
+            toReplace: 'emendatusenigmatica:sulfur_gem',
+            replaceWith: '#forge:gems/sulfur'
+        },
+        {
+            replaceTarget: {},
+            toReplace: 'emendatusenigmatica:steel_block',
+            replaceWith: '#forge:storage_blocks/steel'
         }
     ];
     event.replaceInput({}, 'thermal:sawdust', 'emendatusenigmatica:wood_dust');
@@ -208,19 +228,28 @@ onEvent('recipes', (event) => {
         event.remove({
             id: `minecraft:${color}_carpet_from_white_carpet`
         });
-        fallback_id(event.shaped(Item.of(`minecraft:${color}_carpet`, 3), ['WW'], {
-            W: `minecraft:${color}_wool`
-        }), id_prefix);
+        fallback_id(
+            event.shaped(Item.of(`minecraft:${color}_carpet`, 3), ['WW'], {
+                W: `minecraft:${color}_wool`
+            }),
+            id_prefix
+        );
 
-        fallback_id(event.shaped(Item.of(`minecraft:${color}_stained_glass_pane`, 8), ['GGG', 'GDG', 'GGG'], {
-            G: 'minecraft:glass_pane',
-            D: dyeTag
-        }), id_prefix);
+        fallback_id(
+            event.shaped(Item.of(`minecraft:${color}_stained_glass_pane`, 8), ['GGG', 'GDG', 'GGG'], {
+                G: 'minecraft:glass_pane',
+                D: dyeTag
+            }),
+            id_prefix
+        );
 
-        fallback_id(event.shaped(Item.of(`minecraft:${color}_stained_glass`, 8), ['GGG', 'GDG', 'GGG'], {
-            G: 'minecraft:glass',
-            D: dyeTag
-        }), id_prefix);
+        fallback_id(
+            event.shaped(Item.of(`minecraft:${color}_stained_glass`, 8), ['GGG', 'GDG', 'GGG'], {
+                G: 'minecraft:glass',
+                D: dyeTag
+            }),
+            id_prefix
+        );
 
         ['stained_glass', 'stained_glass_pane', 'terracotta', 'concrete_powder', 'wool', 'carpet'].forEach(
             (blockName) => {
@@ -233,10 +262,13 @@ onEvent('recipes', (event) => {
                     event.remove({ id: block });
                 }
 
-                fallback_id(event.shaped(Item.of(block, 8), ['SSS', 'SDS', 'SSS'], {
-                    S: itemTag,
-                    D: dyeTag
-                }), id_prefix);
+                fallback_id(
+                    event.shaped(Item.of(block, 8), ['SSS', 'SDS', 'SSS'], {
+                        S: itemTag,
+                        D: dyeTag
+                    }),
+                    id_prefix
+                );
                 fallback_id(event.shapeless(Item.of(block, 1), [dyeTag, itemTag]), id_prefix);
             }
         );
@@ -263,17 +295,20 @@ onEvent('recipes', (event) => {
             event.shapeless(Item.of(block, 1), [dyeTag, itemTag]).id(`kubejs:${blockName}_${color}`);
         });
 
-        fallback_id(event.shapeless(Item.of(`minecraft:${color}_concrete_powder`, 8), [
-            dyeTag,
-            '#forge:sand',
-            '#forge:sand',
-            '#forge:sand',
-            '#forge:sand',
-            '#forge:gravel',
-            '#forge:gravel',
-            '#forge:gravel',
-            '#forge:gravel'
-        ]), id_prefix);
+        fallback_id(
+            event.shapeless(Item.of(`minecraft:${color}_concrete_powder`, 8), [
+                dyeTag,
+                '#forge:sand',
+                '#forge:sand',
+                '#forge:sand',
+                '#forge:sand',
+                '#forge:gravel',
+                '#forge:gravel',
+                '#forge:gravel',
+                '#forge:gravel'
+            ]),
+            id_prefix
+        );
     });
 
     const alt_material_tag_replacements = [

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/packing_unpacking.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/packing_unpacking.js
@@ -1,0 +1,211 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/enigmatica/';
+    const recipes = [
+        {
+            output: '9x aquaculture:neptunium_ingot',
+            input: '#forge:storage_blocks/neptunium',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'neptunium_block_to_ingots'
+        },
+        {
+            output: '9x aquaculture:neptunium_nugget',
+            input: '#forge:ingots/neptunium',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'neptunium_ingot_to_nuggets'
+        },
+        {
+            output: 'aquaculture:neptunium_ingot',
+            input: '9x #forge:nuggets/neptunium',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'neptunium_nuggets_to_ingots'
+        },
+        {
+            output: 'aquaculture:neptunium_block',
+            input: '9x #forge:ingots/neptunium',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'neptunium_ingots_to_block'
+        },
+
+        {
+            output: '9x tconstruct:pig_iron_ingot',
+            input: '#forge:storage_blocks/pig_iron',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'pig_iron_block_to_ingots'
+        },
+        {
+            output: '9x tconstruct:pig_iron_nugget',
+            input: '#forge:ingots/pig_iron',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'pig_iron_ingot_to_nuggets'
+        },
+        {
+            output: 'tconstruct:pig_iron_ingot',
+            input: '9x #forge:nuggets/pig_iron',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'pig_iron_nuggets_to_ingots'
+        },
+        {
+            output: 'tconstruct:pig_iron_block',
+            input: '9x #forge:ingots/pig_iron',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'pig_iron_ingots_to_block'
+        },
+
+        {
+            output: '9x materialis:fairy_ingot',
+            input: '#forge:storage_blocks/fairy',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'fairy_block_to_ingots'
+        },
+        {
+            output: '9x materialis:fairy_nugget',
+            input: '#forge:ingots/fairy',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'fairy_ingot_to_nuggets'
+        },
+        {
+            output: 'materialis:fairy_ingot',
+            input: '9x #forge:nuggets/fairy',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'fairy_nuggets_to_ingots'
+        },
+        {
+            output: 'materialis:fairy_block',
+            input: '9x #forge:ingots/fairy',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'fairy_ingots_to_block'
+        },
+
+        {
+            output: '9x eidolon:pewter_ingot',
+            input: '#forge:storage_blocks/pewter',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'pewter_block_to_ingots'
+        },
+        {
+            output: '9x eidolon:pewter_nugget',
+            input: '#forge:ingots/pewter',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'pewter_ingot_to_nuggets'
+        },
+        {
+            output: 'eidolon:pewter_ingot',
+            input: '9x #forge:nuggets/pewter',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'pewter_nuggets_to_ingots'
+        },
+        {
+            output: 'eidolon:pewter_block',
+            input: '9x #forge:ingots/pewter',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'pewter_ingots_to_block'
+        },
+
+        {
+            output: '9x eidolon:arcane_gold_ingot',
+            input: '#forge:storage_blocks/arcane_gold',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'arcane_gold_block_to_ingots'
+        },
+        {
+            output: '9x eidolon:arcane_gold_nugget',
+            input: '#forge:ingots/arcane_gold',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'arcane_gold_ingot_to_nuggets'
+        },
+        {
+            output: 'eidolon:arcane_gold_ingot',
+            input: '9x #forge:nuggets/arcane_gold',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'arcane_gold_nuggets_to_ingots'
+        },
+        {
+            output: 'eidolon:arcane_gold_block',
+            input: '9x #forge:ingots/arcane_gold',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'arcane_gold_ingots_to_block'
+        },
+
+        {
+            output: '9x resourcefulbees:wax',
+            input: '#forge:storage_blocks/wax',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'wax_block_to_wax'
+        },
+        {
+            output: 'resourcefulbees:wax_block',
+            input: '9x #forge:wax',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'wax_to_wax_block'
+        },
+
+        {
+            output: '9x architects_palette:sunmetal_brick',
+            input: '#forge:storage_blocks/sunmetal',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'sunmetal_block_to_ingots'
+        },
+        {
+            output: 'architects_palette:sunmetal_block',
+            input: '9x #forge:ingots/sunmetal',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'sunmetal_ingots_to_block'
+        },
+
+        {
+            output: '9x powah:uraninite',
+            input: '#forge:storage_blocks/uraninite',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'uraninite_block_to_ingots'
+        },
+        {
+            output: 'powah:uraninite_block',
+            input: '9x #forge:ingots/uraninite',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'uraninite_ingots_to_block'
+        },
+
+        {
+            output: '9x thermal:tar',
+            input: '#forge:storage_blocks/tar',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'tar_block_to_tar'
+        },
+        {
+            output: 'thermal:tar_block',
+            input: '9x #forge:tar',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'tar_to_tar_block'
+        },
+
+        {
+            output: '9x integrateddynamics:crystalized_chorus_chunk',
+            input: 'integrateddynamics:crystalized_chorus_block',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'crystalized_chorus_block_to_chunk'
+        },
+        {
+            output: 'integrateddynamics:crystalized_chorus_block',
+            input: '9x integrateddynamics:crystalized_chorus_chunk',
+            mold: '#thermal:crafting/dies/packing_3x3',
+            id_suffix: 'crystalized_chorus_chunk_to_block'
+        }
+    ];
+
+    recipetypes_packing_unpacking = (event, recipe) => {
+        // Thermal
+        event.recipes.thermal
+            .press(recipe.output, [recipe.input, recipe.mold])
+            .energy(2400)
+            .id(`${id_prefix}thermal/press/${recipe.id_suffix}`);
+
+        // Immersiveengineering
+        event.recipes.immersiveengineering
+            .metal_press(recipe.output, recipe.input, recipe.mold)
+            .id(`${id_prefix}immersiveengineering/metal_press/${recipe.id_suffix}`);
+    };
+
+    recipes.forEach((recipe) => {
+        recipetypes_packing_unpacking(event, recipe);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/packing_unpacking.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/packing_unpacking.js
@@ -189,8 +189,118 @@ onEvent('recipes', (event) => {
             input: '9x integrateddynamics:crystalized_chorus_chunk',
             mold: '#thermal:crafting/dies/packing_3x3',
             id_suffix: 'crystalized_chorus_chunk_to_block'
+        },
+
+        {
+            output: '4x minecraft:quartz',
+            input: 'minecraft:quartz_block',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'quartz_block_to_gems'
+        },
+        {
+            output: 'minecraft:quartz_block',
+            input: '4x minecraft:quartz',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'quartz_gems_to_block'
+        },
+
+        {
+            output: '4x minecraft:ender_pearl',
+            input: '#forge:storage_blocks/ender',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'ender_pearl_block_to_gems'
+        },
+        {
+            output: 'betterendforge:ender_block',
+            input: '4x #forge:gems/ender',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'ender_pearl_gems_to_block'
+        },
+
+        {
+            output: '4x minecraft:glowstone_dust',
+            input: '#forge:storage_blocks/glowstone',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'glowstone_block_to_dust'
+        },
+        {
+            output: 'minecraft:glowstone',
+            input: '4x #forge:dusts/glowstone',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'glowstone_dust_to_block'
+        },
+
+        {
+            output: '4x minecraft:clay_ball',
+            input: '#forge:storage_blocks/clay',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'clay_block_to_dust'
+        },
+        {
+            output: 'minecraft:clay',
+            input: '4x #forge:clay',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'clay_ball_to_block'
+        },
+
+        {
+            output: '4x thermal:slag',
+            input: '#forge:storage_blocks/slag',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'slag_block_to_slag'
+        },
+        {
+            output: 'thermal:slag_block',
+            input: '4x #forge:slag',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'slag_to_slag_block'
+        },
+
+        {
+            output: '4x betterendforge:crystal_shards',
+            input: '#forge:storage_blocks/aurora',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'aurora_block_to_shards'
+        },
+        {
+            output: 'betterendforge:aurora_crystal',
+            input: '4x #forge:shards/aurora',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'aurora_shards_to_block'
+        },
+
+        {
+            output: '4x betterendforge:amber_gem',
+            input: '#forge:storage_blocks/amber',
+            mold: '#thermal:crafting/dies/unpacking',
+            id_suffix: 'amber_block_to_gems'
+        },
+        {
+            output: 'betterendforge:amber_block',
+            input: '4x #forge:gems/amber',
+            mold: '#thermal:crafting/dies/packing_2x2',
+            id_suffix: 'amber_gems_to_block'
         }
     ];
+
+    let botania_quartz_types = ['dark', 'mana', 'blaze', 'lavender', 'red', 'elven', 'sunny'];
+
+    botania_quartz_types.forEach((type) => {
+        recipes.push(
+            {
+                output: `4x botania:quartz_${type}`,
+                input: `botania:${type == 'elven' ? 'elf' : type}_quartz`,
+                mold: '#thermal:crafting/dies/unpacking',
+                id_suffix: `${type}_quartz_block_to_gems`
+            },
+            {
+                output: `botania:${type == 'elven' ? 'elf' : type}_quartz`,
+                input: `4x botania:quartz_${type}`,
+                mold: '#thermal:crafting/dies/packing_2x2',
+                id_suffix: `${type}_quartz_gems_to_block`
+            }
+        );
+    });
 
     recipetypes_packing_unpacking = (event, recipe) => {
         // Thermal

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shaped.js
@@ -373,6 +373,70 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}thermal/white_rockwool_from_washing`
         },
         {
+            output: 'mekanism:block_refined_obsidian',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:ingots/refined_obsidian'
+            },
+            id: `${id_prefix}refined_obsidian_block_from_ingots`
+        },
+        {
+            output: 'mekanism:ingot_refined_obsidian',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:nuggets/refined_obsidian'
+            },
+            id: `${id_prefix}refined_obsidian_ingot_from_nuggets`
+        },
+        {
+            output: 'mekanism:block_refined_glowstone',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:ingots/refined_glowstone'
+            },
+            id: `${id_prefix}refined_glowstone_block_from_ingots`
+        },
+        {
+            output: 'mekanism:ingot_refined_glowstone',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:nuggets/refined_glowstone'
+            },
+            id: `${id_prefix}refined_glowstone_ingot_from_nuggets`
+        },
+        {
+            output: 'thermal:gunpowder_block',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:gunpowder'
+            },
+            id: `${id_prefix}gunpowder_block`
+        },
+        {
+            output: 'thermal:tar_block',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:tar'
+            },
+            id: `${id_prefix}tar_block`
+        },
+        {
+            output: 'occultism:iesnium_block',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:ingots/iesnium'
+            },
+            id: `${id_prefix}iesnium_block_from_ingots`
+        },
+        {
+            output: 'occultism:iesnium_ingot',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:nuggets/iesnium'
+            },
+            id: `${id_prefix}iesnium_ingot_from_nuggets`
+        },
+        {
             output: Item.of('morphtool:tool', {
                 'morphtool:data': {
                     blockcarpentry: { id: 'blockcarpentry:texture_wrench', Count: 1 },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/shapeless.js
@@ -1,0 +1,49 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/enigmatica/shapeless/';
+    const recipes = [
+        {
+            output: '9x mekanism:ingot_refined_obsidian',
+            inputs: ['#forge:storage_blocks/refined_obsidian'],
+            id: `${id_prefix}refined_obsidian_ingots_from_block`
+        },
+        {
+            output: '9x mekanism:nugget_refined_obsidian',
+            inputs: ['#forge:ingots/refined_obsidian'],
+            id: `${id_prefix}refined_obsidian_nuggets_from_ingot`
+        },
+        {
+            output: '9x mekanism:ingot_refined_glowstone',
+            inputs: ['#forge:storage_blocks/refined_glowstone'],
+            id: `${id_prefix}refined_glowstone_ingots_from_block`
+        },
+        {
+            output: '9x mekanism:nugget_refined_glowstone',
+            inputs: ['#forge:ingots/refined_glowstone'],
+            id: `${id_prefix}refined_glowstone_nuggets_from_ingot`
+        },
+        {
+            output: '9x minecraft:gunpowder',
+            inputs: ['#forge:storage_blocks/gunpowder'],
+            id: `${id_prefix}gunpowder_from_block`
+        },
+        {
+            output: '9x thermal:tar',
+            inputs: ['#forge:storage_blocks/tar'],
+            id: `${id_prefix}tar_from_block`
+        },
+        {
+            output: '9x occultism:iesnium_ingot',
+            inputs: ['#forge:storage_blocks/iesnium'],
+            id: `${id_prefix}iesnium_ingots_from_block`
+        },
+        {
+            output: '9x occultism:iesnium_nugget',
+            inputs: ['#forge:ingots/iesnium'],
+            id: `${id_prefix}iesnium_nuggets_from_ingot`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
@@ -1,8 +1,6 @@
 onEvent('item.tags', (event) => {
     sharedDies.forEach((die) => {
-        event.add('thermal:crafting/dies', [`#thermal:crafting/dies/${die.thermalName}`]);
         event.add(`thermal:crafting/dies/${die.thermalName}`, [
-            `thermal:press_${die.thermalName}_die`,
             `immersiveengineering:mold_${die.immersiveEngineeringName}`
         ]);
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -27,6 +27,8 @@ onEvent('recipes', (event) => {
         let rod = getPreferredItemInTag(Ingredient.of(`#forge:rods/${material}`)).id;
         let plate = getPreferredItemInTag(Ingredient.of(`#forge:plates/${material}`)).id;
 
+        let coin = getPreferredItemInTag(Ingredient.of(`#forge:coins/${material}`)).id;
+
         astralsorcery_ore_processing_infuser(event, material, ore, ingot, gem, shard);
 
         betterend_alloys(event, material, ore, ingot);
@@ -48,6 +50,7 @@ onEvent('recipes', (event) => {
         immersiveengineering_gem_ore_processing(event, material, ore, dust, gem, shard);
         immersiveengineering_hammer_crushing(event, material, ore, dust, gem);
         immersiveengineering_gem_crushing(event, material, dust, gem);
+        immersiveengineering_coin_pressing(event, material, ingot, nugget, coin);
 
         mekanism_ingot_gem_crushing(event, material, ingot, dust, gem);
         mekanism_gem_ore_processing(event, material, ore, dust, gem, shard);
@@ -82,10 +85,11 @@ onEvent('recipes', (event) => {
         thermal_metal_melting(event, material, block, ingot, nugget, gear, rod, plate);
         thermal_gem_casting(event, material, gem, gear, rod, plate);
         thermal_gem_melting(event, material, block, gem, gear, rod, plate);
-        thermal_nugget_packing_unpacking(event, material, ingot, nugget);
 
         tconstruct_metal_casting(event, material, block, ingot, nugget, gear, rod, plate);
         tconstruct_gem_casting(event, material, block, gem, gear, rod, plate);
+
+        material_packing_unpacking(event, material, block, ingot, gem, nugget);
     });
 
     function astralsorcery_ore_processing_infuser(event, material, ore, ingot, gem, shard) {
@@ -127,22 +131,25 @@ onEvent('recipes', (event) => {
                 break;
         }
 
-        fallback_id(event.custom({
-            type: 'astralsorcery:infuser',
-            fluidInput: 'astralsorcery:liquid_starlight',
-            input: {
-                tag: input
-            },
-            output: {
-                item: output,
-                count: count
-            },
-            consumptionChance: 0.1,
-            duration: 100,
-            consumeMultipleFluids: false,
-            acceptChaliceInput: true,
-            copyNBTToOutputs: false
-        }), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.custom({
+                type: 'astralsorcery:infuser',
+                fluidInput: 'astralsorcery:liquid_starlight',
+                input: {
+                    tag: input
+                },
+                output: {
+                    item: output,
+                    count: count
+                },
+                consumptionChance: 0.1,
+                duration: 100,
+                consumeMultipleFluids: false,
+                acceptChaliceInput: true,
+                copyNBTToOutputs: false
+            }),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function betterend_alloys(event, material, ore, ingot) {
@@ -150,13 +157,16 @@ onEvent('recipes', (event) => {
             return;
         }
         var tag = `forge:ores/${material}`;
-        fallback_id(event.custom({
-            type: 'betterendforge:alloying',
-            ingredients: [{ tag: tag }, { tag: tag }],
-            result: Ingredient.of(ingot, 3),
-            experience: 2,
-            smelttime: 300
-        }), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.custom({
+                type: 'betterendforge:alloying',
+                ingredients: [{ tag: tag }, { tag: tag }],
+                result: Ingredient.of(ingot, 3),
+                experience: 2,
+                smelttime: 300
+            }),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function bloodmagic_metal_ore_processing(event, material, ore, fragment, gravel, dust, ingot) {
@@ -240,7 +250,14 @@ onEvent('recipes', (event) => {
         }
 
         // Alchemy Table Processing
-        fallback_id(event.recipes.bloodmagic.alchemytable(Item.of(output, count), inputs).syphon(400).ticks(200).upgradeLevel(1), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.recipes.bloodmagic
+                .alchemytable(Item.of(output, count), inputs)
+                .syphon(400)
+                .ticks(200)
+                .upgradeLevel(1),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
     function bloodmagic_ingot_gem_crushing(event, material, ingot, dust, gem) {
         if (dust == air) {
@@ -386,7 +403,10 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        fallback_id(event.recipes.create.milling(outputs, input).processingTime(processingTime), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.recipes.create.milling(outputs, input).processingTime(processingTime),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function create_metal_block_processing(event, material, crushed_ore, ingot, nugget) {
@@ -561,7 +581,33 @@ onEvent('recipes', (event) => {
         var output = dust,
             input = `#forge:gems/${material}`;
 
-        fallback_id(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.recipes.immersiveengineering.crusher(output, input).energy(2000),
+            `${id_prefix}${arguments.callee.name}/`
+        );
+    }
+    function immersiveengineering_coin_pressing(event, material, ingot, nugget, coin) {
+        if (ingot == air || nugget == air || coin == air) {
+            return;
+        }
+
+        var output = Item.of(coin, 3),
+            input = `#forge:ingots/${material}`,
+            mold = `#thermal:crafting/dies/coin`;
+
+        // Ingots to Coins
+        fallback_id(
+            event.recipes.immersiveengineering.metal_press(output, input, mold),
+            `${id_prefix}${arguments.callee.name}/`
+        );
+
+        // Nuggets to Coins
+        output = coin;
+        input = `3x #forge:nuggets/${material}`;
+        fallback_id(
+            event.recipes.immersiveengineering.metal_press(output, input, mold),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function immersiveengineering_ingot_crushing(event, material, dust, ingot) {
@@ -573,7 +619,10 @@ onEvent('recipes', (event) => {
             var output = dust,
                 input = `#forge:ingots/${material}`;
 
-            fallback_id(event.recipes.immersiveengineering.crusher(output, input).energy(2000), `${id_prefix}${arguments.callee.name}/`);
+            fallback_id(
+                event.recipes.immersiveengineering.crusher(output, input).energy(2000),
+                `${id_prefix}${arguments.callee.name}/`
+            );
         }
     }
 
@@ -865,13 +914,16 @@ onEvent('recipes', (event) => {
                 return;
         }
 
-        fallback_id(event.custom({
-            type: 'occultism:crushing',
-            ingredient: { tag: input },
-            result: { item: output, count: count },
-            crushing_time: 100,
-            ignore_crushing_multiplier: false
-        }), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.custom({
+                type: 'occultism:crushing',
+                ingredient: { tag: input },
+                result: { item: output, count: count },
+                crushing_time: 100,
+                ignore_crushing_multiplier: false
+            }),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function occultism_metal_ore_crushing(event, material, ore, dust, ingot) {
@@ -917,13 +969,16 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        fallback_id(event.custom({
-            type: 'occultism:crushing',
-            ingredient: { tag: input },
-            result: { item: output, count: 1 },
-            crushing_time: 100,
-            ignore_crushing_multiplier: true
-        }), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.custom({
+                type: 'occultism:crushing',
+                ingredient: { tag: input },
+                result: { item: output, count: 1 },
+                crushing_time: 100,
+                ignore_crushing_multiplier: true
+            }),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function pedestals_gem_ore_crushing(event, material, ore, dust, shard, gem) {
@@ -1004,16 +1059,19 @@ onEvent('recipes', (event) => {
             return;
         }
 
-        fallback_id(event.custom({
-            type: 'pedestals:pedestal_crushing',
-            ingredient: {
-                tag: input
-            },
-            result: {
-                item: output,
-                count: 1
-            }
-        }), `${id_prefix}${arguments.callee.name}/`);
+        fallback_id(
+            event.custom({
+                type: 'pedestals:pedestal_crushing',
+                ingredient: {
+                    tag: input
+                },
+                result: {
+                    item: output,
+                    count: 1
+                }
+            }),
+            `${id_prefix}${arguments.callee.name}/`
+        );
     }
 
     function thermal_metal_ore_pulverizing(event, material, ore, dust, ingot) {
@@ -1314,35 +1372,6 @@ onEvent('recipes', (event) => {
                 .crucible(Fluid.of(`${modId}:molten_${material}`, recipe.amount), recipe.input)
                 .energy(recipe.energy)
                 .id(`enigmatica:base/thermal/crucible/${material}_${recipe.type}`);
-        })
-    }
-
-    function thermal_nugget_packing_unpacking(event, material, ingot, nugget) {
-        if (ingot == air || nugget == air){
-            return;
-        }
-        let recipes = [
-            {
-                inputs: [
-                    Item.of(nugget, 9),
-                    Ingredient.of('#thermal:crafting/dies/packing_3x3')
-                ],
-                outputs: [Item.of(ingot, 1)],
-                energy: 2400,
-                id: `thermal:machine/press/packing3x3/press_${material}_packing`
-            },
-            {
-                inputs: [
-                    Item.of(ingot, 1),
-                    Ingredient.of('#thermal:crafting/dies/unpacking')
-                ],
-                outputs: [Item.of(nugget, 9)],
-                energy: 2400,
-                id: `thermal:machine/press/unpacking/press_${material}_packing`
-            }
-        ]
-        recipes.forEach((recipe) => {
-            event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy).id(recipe.id);
         });
     }
 
@@ -1474,5 +1503,81 @@ onEvent('recipes', (event) => {
                 cooling_time: 193
             })
             .id(`tconstruct:smeltery/casting/${material}/block`);
+    }
+
+    function material_packing_unpacking(event, material, block, ingot, gem, nugget) {
+        blacklistedMaterials = ['ender', 'amber', 'quartz'];
+        for (var i = 0; i < blacklistedMaterials.length; i++) {
+            if (blacklistedMaterials[i] == material) {
+                return;
+            }
+        }
+
+        let recipes = [];
+
+        if (block !== air && ingot !== air) {
+            //compact ingot to block
+            recipes.push({
+                output: block,
+                input: `9x #forge:ingots/${material}`,
+                mold: '#thermal:crafting/dies/packing_3x3',
+                id_suffix: `${material}_ingots_to_block`
+            });
+
+            //split block to ingot
+            recipes.push({
+                output: Item.of(ingot, 9),
+                input: `#forge:storage_blocks/${material}`,
+                mold: '#thermal:crafting/dies/unpacking',
+                id_suffix: `${material}_block_to_ingots`
+            });
+        }
+
+        if (block !== air && gem !== air) {
+            //compact gem to block
+            recipes.push({
+                output: block,
+                input: `9x #forge:gems/${material}`,
+                mold: '#thermal:crafting/dies/packing_3x3',
+                id_suffix: `${material}_gems_to_block`
+            });
+
+            //split block to gem
+            recipes.push({
+                output: Item.of(gem, 9),
+                input: `#forge:storage_blocks/${material}`,
+                mold: '#thermal:crafting/dies/unpacking',
+                id_suffix: `${material}_block_to_gems`
+            });
+        }
+
+        if (ingot !== air && nugget !== air) {
+            //compact nugget to ingot
+            recipes.push({
+                output: ingot,
+                input: `9x #forge:nuggets/${material}`,
+                mold: '#thermal:crafting/dies/packing_3x3',
+                id_suffix: `${material}_nuggets_to_ingot`
+            });
+
+            //split ingot to nugget
+            recipes.push({
+                output: Item.of(nugget, 9),
+                input: `#forge:ingots/${material}`,
+                mold: '#thermal:crafting/dies/unpacking',
+                id_suffix: `${material}_ingot_to_nuggets`
+            });
+        }
+
+        recipes.forEach((recipe) => {
+            event.recipes.thermal
+                .press(recipe.output, [recipe.input, recipe.mold])
+                .energy(2400)
+                .id(`${id_prefix}thermal/press/${recipe.id_suffix}`);
+
+            event.recipes.immersiveengineering
+                .metal_press(recipe.output, recipe.input, recipe.mold)
+                .id(`${id_prefix}immersiveengineering/metal_press/${recipe.id_suffix}`);
+        });
     }
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -2282,6 +2282,12 @@ const stonecuttables = [
         ],
         onlyAsOutput: [],
         onlyAsInput: []
+    },
+    {
+        name: 'bamboo',
+        stones: ['quark:bamboo_block', 'thermal:bamboo_block'],
+        onlyAsOutput: [],
+        onlyAsInput: []
     }
 ];
 // Colorless Glass

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/metal_press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/metal_press.js
@@ -9,6 +9,30 @@ onEvent('recipes', (event) => {
             input: 'immersiveengineering:thermoelectric_generator',
             mold: '#thermal:crafting/dies/plate',
             id: `${id_prefix}thermoelectric_plate`
+        },
+        {
+            output: 'refinedstorage:basic_processor',
+            input: 'refinedstorage:raw_basic_processor',
+            mold: '#thermal:crafting/dies/coin',
+            id: `${id_prefix}basic_processor`
+        },
+        {
+            output: 'refinedstorage:improved_processor',
+            input: 'refinedstorage:raw_improved_processor',
+            mold: '#thermal:crafting/dies/coin',
+            id: `${id_prefix}improved_processor`
+        },
+        {
+            output: 'refinedstorage:advanced_processor',
+            input: 'refinedstorage:raw_advanced_processor',
+            mold: '#thermal:crafting/dies/coin',
+            id: `${id_prefix}advanced_processor`
+        },
+        {
+            output: 'extrastorage:neural_processor',
+            input: 'extrastorage:raw_neural_processor',
+            mold: '#thermal:crafting/dies/coin',
+            id: `${id_prefix}neural_processor`
         }
     ];
 


### PR DESCRIPTION
Primarily addresses #4857

Removes thermal packing/unpacking dies from the tags, as the IE metal press can't seem to deal with this and just picks one from the tag to work with.

Re-works nugget > ingot > block packing and block > ingot > nugget unpacking. 

Re-adds some missing 3x3 recipes for doing the same, notably iesnium (#4903), pig iron, and refined glowstone/obsidian.

Adds 2x2 and 3x3 packing/unpacking support for a lot of blocks. There's probably a fair few more that would be nice to have. Can add these as they come up.

Adds Coin and (expert only) Processor patterns to the IE Metal Press since it seems IE will work with the Thermal Dies afterall. 