### PR TITLE
Update Astral Wood Recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/shaped.js
@@ -1,0 +1,70 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/astralsorcery/shaped/';
+    /*
+        ,
+        {
+            output: '',
+            pattern: ['', '', ''],
+            key: {
+                A: ''
+            },
+            id: ''
+        }
+    */
+
+    const recipes = [
+        {
+            output: '8x astralsorcery:infused_wood_stairs',
+            pattern: ['A  ', 'AA ', 'AAA'],
+            key: {
+                A: 'astralsorcery:infused_wood_planks'
+            },
+            id: `${id_prefix}infused_wood_stairs`
+        },
+        {
+            output: '2x astralsorcery:infused_wood_arch',
+            pattern: ['AA '],
+            key: {
+                A: 'astralsorcery:infused_wood_planks'
+            },
+            id: `${id_prefix}infused_wood_arch`
+        },
+        {
+            output: '6x astralsorcery:infused_wood_slab',
+            pattern: ['AAA'],
+            key: {
+                A: 'astralsorcery:infused_wood_planks'
+            },
+            id: `${id_prefix}infused_wood_slab`
+        },
+        {
+            output: '2x astralsorcery:infused_wood_column',
+            pattern: ['A', 'A'],
+            key: {
+                A: 'astralsorcery:infused_wood_planks'
+            },
+            id: `${id_prefix}infused_wood_column`
+        },
+        {
+            output: '4x astralsorcery:infused_wood_engraved',
+            pattern: [' A ', 'A A', ' A '],
+            key: {
+                A: 'astralsorcery:infused_wood_planks'
+            },
+            id: `${id_prefix}infused_wood_engraved`
+        },
+        {
+            output: '4x astralsorcery:infused_wood_enriched',
+            pattern: [' A ', 'ABA', ' A '],
+            key: {
+                A: 'astralsorcery:infused_wood_planks',
+                B: '#forge:gems/aquamarine'
+            },
+            id: `${id_prefix}infused_wood_enriched`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/shapeless.js
@@ -1,0 +1,14 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/astralsorcery/shapeless/';
+    const recipes = [
+        {
+            output: '4x astralsorcery:infused_wood_planks',
+            inputs: ['astralsorcery:infused_wood'],
+            id: `${id_prefix}infused_wood_planks`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/cutting.js
@@ -30,6 +30,11 @@ onEvent('recipes', (event) => {
             input: 'botania:livingwood',
             outputs: [Item.of('6x botania:livingwood_planks'), Item.of('emendatusenigmatica:wood_dust').chance(0.25)],
             id: `${id_prefix}livingwood_planks_from_livingwood`
+        },
+        {
+            input: 'astralsorcery:infused_wood',
+            outputs: [Item.of('6x astralsorcery:infused_wood_planks'), Item.of('astralsorcery:stardust').chance(0.01)],
+            id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/cutting.js
@@ -40,7 +40,7 @@ onEvent('recipes', (event) => {
         {
             input: 'astralsorcery:infused_wood',
             output: Item.of('6x astralsorcery:infused_wood_planks'),
-            extraOutput: Item.of('astralsorcery:stardust').chance(0.01),
+            extraOutput: Item.of('astralsorcery:stardust').chance(0.03),
             id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/cutting.js
@@ -36,6 +36,12 @@ onEvent('recipes', (event) => {
             output: Item.of('6x botania:livingwood_planks'),
             extraOutput: Item.of('emendatusenigmatica:wood_dust').chance(0.25),
             id: `${id_prefix}livingwood_planks_from_livingwood`
+        },
+        {
+            input: 'astralsorcery:infused_wood',
+            output: Item.of('6x astralsorcery:infused_wood_planks'),
+            extraOutput: Item.of('astralsorcery:stardust').chance(0.01),
+            id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/sawing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/sawing.js
@@ -40,7 +40,7 @@ onEvent('recipes', (event) => {
         {
             input: ['astralsorcery:infused_wood'],
             output: Item.of('6x astralsorcery:infused_wood_planks'),
-            extraOutput: Item.of('astralsorcery:stardust').chance(0.01),
+            extraOutput: Item.of('astralsorcery:stardust').chance(0.05),
             id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/sawing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/sawing.js
@@ -36,6 +36,12 @@ onEvent('recipes', (event) => {
             output: Item.of('6x botania:livingwood_planks'),
             extraOutput: Item.of('emendatusenigmatica:wood_dust').chance(0.25),
             id: `${id_prefix}livingwood_planks_from_livingwood`
+        },
+        {
+            input: ['astralsorcery:infused_wood'],
+            output: Item.of('6x astralsorcery:infused_wood_planks'),
+            extraOutput: Item.of('astralsorcery:stardust').chance(0.01),
+            id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_sawing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_sawing.js
@@ -15,6 +15,11 @@ onEvent('recipes', (event) => {
             input: 'botania:livingwood',
             output: '6x botania:livingwood_planks',
             id: `${id_prefix}livingwood_planks_from_livingwood`
+        },
+        {
+            input: 'astralsorcery:infused_wood',
+            output: '6x astralsorcery:infused_wood_planks',
+            id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/sawmill.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/sawmill.js
@@ -30,6 +30,11 @@ onEvent('recipes', (event) => {
             input: ['botania:livingwood'],
             outputs: [Item.of('6x botania:livingwood_planks'), Item.of('emendatusenigmatica:wood_dust').chance(0.25)],
             id: `${id_prefix}livingwood_planks_from_livingwood`
+        },
+        {
+            input: ['astralsorcery:infused_wood'],
+            outputs: [Item.of('6x astralsorcery:infused_wood_planks'), Item.of('astralsorcery:stardust').chance(0.01)],
+            id: `${id_prefix}infused_wood_planks_from_infused_wood`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/shaped.js
@@ -3,6 +3,7 @@ onEvent('recipes', (event) => {
         return;
     }
 
+    const id_prefix = 'enigmatica:expert/astralsorcery/shaped/';
     /*
         ,
         {
@@ -15,7 +16,7 @@ onEvent('recipes', (event) => {
         }
     */
 
-    const newRecipes = [
+    const recipes = [
         {
             output: 'astralsorcery:linking_tool',
             pattern: [' CD', ' AC', 'AB '],
@@ -56,11 +57,7 @@ onEvent('recipes', (event) => {
         }
     ];
 
-    newRecipes.forEach((recipe) => {
-        if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
-        } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
-        }
+    recipes.forEach((recipe) => {
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -227,6 +227,14 @@ onEvent('recipes', (event) => {
             aura: 300000,
             time: 1000,
             id: `${id_prefix}birth_spirit`
+        },
+        {
+            input: 'astralsorcery:infused_wood',
+            output: { item: 'astralsorcery:infused_wood_infused' },
+            aura_type: 'naturesaura:overworld',
+            aura: 500,
+            time: 100,
+            id: `astralsorcery:infuser/infused_wood`
         }
     ];
 


### PR DESCRIPTION
Moves Vibrant Infused Wood to the Natural Altar (Expert only). Resolves #4825
![image](https://user-images.githubusercontent.com/9543430/170737246-f05f0be2-25b7-496a-b1a7-a58cbf210791.png)

All Astral Wood recipes get a copy in the standard crafting table. Same as the Luminous Crafing Recipes
![image](https://user-images.githubusercontent.com/9543430/170737343-d9b9e4a4-e816-4e93-8c5d-98300915cb03.png)
![image](https://user-images.githubusercontent.com/9543430/170737376-2e95ab59-3132-440f-be39-b900a1edc465.png)
![image](https://user-images.githubusercontent.com/9543430/170737398-b9508b20-1894-489d-ada3-ee1e95cba641.png)

Planks added to all saw recipes. 
![image](https://user-images.githubusercontent.com/9543430/170737457-bfe3bec5-fc80-4922-bc80-8d010484d72e.png)

Thought it would be cool if these gave a very small amount of stardust instead of the usual 25% chance of sawdust when cutting planks. Open to changing this, but seeing as stardust is generally not hard to come by, I don't think this is terribly imbalanced for normal or expert.
Could even go with a higher percentage if desired. 
