### PR TITLE
`ci` download mods once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
   #         - 'master'
 
 jobs:
-  mods:
+  # job
+  instancesync:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -27,9 +28,9 @@ jobs:
           key: ${{ github.run.id }}-mods
 
       - run: java -jar InstanceSync.jar
-
+  # job
   server:
-    needs: [mods]
+    needs: [instancesync]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -79,6 +80,7 @@ jobs:
             ./logs
             ./crash-reports
             ./kubejs/exported/recipes
+  # job
   kubejs:
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,25 @@ on:
   #         - 'master'
 
 jobs:
+  mods:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - uses: actions/cache@v3
+        with:
+          path: mods
+          key: ${{ github.run.id }}-mods
+
+      - run: java -jar InstanceSync.jar
+
   server:
+    needs: [mods]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -26,6 +44,11 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - uses: actions/cache@v3
+        with:
+          path: mods
+          key: ${{ github.run.id }}-mods
+
       - name: Setting mode to ${{ matrix.packmode }}
         run: |
           node .github/actions/ci/packmode.js ${{ matrix.packmode }} > mode.json
@@ -33,7 +56,6 @@ jobs:
 
       - name: Install server
         run: |
-          java -jar InstanceSync.jar
           cp ./automation/settings.cfg ./settings.cfg
           cp ./automation/start-automated-server.sh ./start-automated-server.sh
           pwsh ./automation/remove-client-mods.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   # job
   instancesync:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: mods
-          key: ${{ github.run.id }}-mods
+          key: ${{ github.run_id }}-mods
 
       - run: java -jar InstanceSync.jar
   # job
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: mods
-          key: ${{ github.run.id }}-mods
+          key: ${{ github.run_id }}-mods
 
       - name: Setting mode to ${{ matrix.packmode }}
         run: |


### PR DESCRIPTION
Download the mods just once instead of for both normal & expert, kinder on the curseforge cdn: 
![Screen Shot 2022-05-28 at 09 52 43](https://user-images.githubusercontent.com/3179271/170816281-c3b8e18c-b133-43b8-8a5f-47bf5e2adfe7.png)
(this does not cache/lock them to a hash of minecraftinstance.json between runs, in order to quickly spot download issues)
