### PR TITLE
Remove extra bottling recipes for XP.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -247,6 +247,7 @@ onEvent('recipes', (event) => {
         'thermal:machine/press/unpacking/press_quartz_unpacking',
         'thermal:machine/press/packing2x2/press_slag_packing',
         'thermal:machine/press/unpacking/press_slag_unpacking',
+        'thermal:compat/industrialforegoing/bottler_essence',
 
         'pneumaticcraft:one_probe_crafting',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/bottler.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/bottler.js
@@ -14,12 +14,6 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}hot_cocoa`
         },
         {
-            input: 'minecraft:glass_bottle',
-            fluid: Fluid.of('pneumaticcraft:memory_essence', 250),
-            output: 'minecraft:experience_bottle',
-            id: `${id_prefix}experience_bottle`
-        },
-        {
             input: 'buildinggadgets:construction_block_powder',
             fluid: Fluid.of('minecraft:water', 1000),
             output: 'buildinggadgets:construction_block_dense',


### PR DESCRIPTION
These are both handled by tags in the default thermal recipes now.