### PR TITLE
Better document what fluids are allowed for infinite draining

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -507,6 +507,31 @@ onEvent('jei.information', (event) => {
         {
             items: ['naturesaura:birth_spirit'],
             text: [`Obtained by manually breeding animals in high Aura areas.`]
+        },
+        {
+            items: ['create:hose_pulley'],
+            text: [
+                `May be used to pump the following infinitely:`,
+                ` `,
+                `● Lava`,
+                `● Water`,
+                `● Milk`,
+                `● Latex`,
+                `● Sewage`,
+                `● Sludge`,
+                `● Crude Oil`,
+                `● Resin`,
+                `● Sap`,
+                `● Virulent Mix`,
+                `● Builder's Tea`,
+                `● Chocolate`,
+                `● Liquid Chorus`,
+                `● Menril Resin`,
+                `● Blood`,
+                `● Slime`,
+                `● Enderslime`,
+                `● Skyslime`
+            ]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/create/no_infinite_draining.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/create/no_infinite_draining.js
@@ -1,35 +1,50 @@
 onEvent('fluid.tags', (event) => {
+    let draining_whitelist = [
+        'create:chocolate',
+        'create:tea',
+        'immersivepetroleum:oil',
+        'industrialforegoing:latex',
+        'industrialforegoing:sewage',
+        'industrialforegoing:sludge',
+        'integrateddynamics:liquid_chorus',
+        'integrateddynamics:menril_resin',
+        'minecraft:lava',
+        'minecraft:milk',
+        'minecraft:water',
+        'pneumaticcraft:oil',
+        'tconstruct:blood',
+        'tconstruct:earth_slime',
+        'tconstruct:ender_slime',
+        'tconstruct:sky_slime',
+        'thermal:crude_oil',
+        'thermal:latex',
+        'thermal:resin',
+        'thermal:sap',
+        'undergarden:virulent_mix_source'
+    ];
+
     event
         .get('create:no_infinite_draining')
         .add([
-            /tconstruct/,
-            /mekanism/,
+            /astralsorcery/,
+            /cofh_core/,
+            /create/,
+            /decorative_blocks/,
             /emendatusenigmatica/,
+            /immersiveengineering/,
+            /immersivepetroleum/,
+            /industrialforegoing/,
+            /integrateddynamics/,
             /kubejs/,
             /materialis/,
-            /chorus/,
-            /essence/,
-            /meat/,
-            /slime/,
-            /bio/,
-            /diesel/,
-            /ethanol/,
-            /gasoline/,
-            /kerosene/,
-            /lpg/,
-            /lubricant/,
-            /plastic/,
-            /napalm/,
-            /potion/,
-            /creosote/,
-            /honey/,
-            /syrup/,
-            /tree_oil/,
-            /light_oil/,
-            /heavy_oil/,
-            /fuel/,
-            /plantoil/,
-            /vegetable_oil/,
-            /yeast/
-        ]);
+            /mekanism/,
+            /minecraft/,
+            /pneumaticcraft/,
+            /sophisticatedbackpacks/,
+            /tconstruct/,
+            /thermal/
+        ])
+        .remove(draining_whitelist);
+
+    event.get('create:allow_infinite_draining').add(draining_whitelist);
 });


### PR DESCRIPTION
Updates the list to be a little easier to read in the code, basically blacklisting everything and removing a specific whitelist instead. 

This also adds a few new entries, notably blood, slime, sky slime, and ender slime. The reason being that these can be gotten from trees now, and so are treated just like other tree products, such as latex, sap, and resin. 

![image](https://user-images.githubusercontent.com/9543430/171074771-eee7ada9-8781-4d94-b072-4d9cc15809eb.png)
![image](https://user-images.githubusercontent.com/9543430/171074783-14e0dd25-8972-4c69-8432-95c505800175.png)
