### PR TITLE
QOL Recipe to reset Refined Storage and Extra Storage crafter NBT

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/extrastorage/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/extrastorage/shapeless.js
@@ -1,0 +1,19 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/extrastorage/';
+
+    let crafter_tiers = ['iron', 'gold', 'diamond', 'netherite'];
+
+    const recipes = [];
+
+    crafter_tiers.forEach((crafter_tier) => {
+        recipes.push({
+            output: `extrastorage:${crafter_tier}_crafter`,
+            inputs: [Item.of(`extrastorage:${crafter_tier}_crafter`).ignoreNBT()],
+            id: `${id_prefix}${crafter_tier}crafter_reset`
+        });
+    });
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/refinedstorage/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/refinedstorage/shapeless.js
@@ -1,0 +1,14 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/refinedstorage/';
+    const recipes = [
+        {
+            output: 'refinedstorage:crafter',
+            inputs: [Item.of('refinedstorage:crafter').ignoreNBT()],
+            id: `${id_prefix}crafter_reset`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});


### PR DESCRIPTION
I frequently find myself wanting to have a crafter reset back to the default name, allowing it to pick up the name from whatever it's pointed at. This adds a recipe to do so.