### PR TITLE
Remove the name from amadron mineral survey chests

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/amadron.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/amadron.js
@@ -10,7 +10,7 @@ onEvent('recipes', (event) => {
                 type: 'ITEM',
                 id: 'pneumaticcraft:reinforced_chest',
                 amount: 1,
-                nbt: `{display:{Name:'[{"text":"Atum Mineral Survey"}]',Lore:['[{"text":"A collection of minerals from Atum.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_atum_combo"}}`
+                nbt: `{display:{Lore:['[{"text":"A collection of minerals from Atum.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_atum_combo"}}`
             },
             level: 0,
             maxStock: 5,
@@ -24,7 +24,7 @@ onEvent('recipes', (event) => {
                 type: 'ITEM',
                 id: 'pneumaticcraft:reinforced_chest',
                 amount: 1,
-                nbt: `{display:{Name:'[{"text":"Undergarden Mineral Survey"}]',Lore:['[{"text":"A collection of minerals from the Undergarden.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_undergarden_combo"}}`
+                nbt: `{display:{Lore:['[{"text":"A collection of minerals from the Undergarden.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_undergarden_combo"}}`
             },
             level: 0,
             maxStock: 5,
@@ -38,7 +38,7 @@ onEvent('recipes', (event) => {
                 type: 'ITEM',
                 id: 'pneumaticcraft:reinforced_chest',
                 amount: 1,
-                nbt: `{display:{Name:'[{"text":"Nether Botanical Survey"}]',Lore:['[{"text":"A collection of botanical samples from the Nether.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_botanical_survey_nether_combo"}}`
+                nbt: `{display:{Lore:['[{"text":"A collection of botanical samples from the Nether.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_botanical_survey_nether_combo"}}`
             },
             level: 0,
             maxStock: 5,
@@ -52,7 +52,7 @@ onEvent('recipes', (event) => {
                 type: 'ITEM',
                 id: 'pneumaticcraft:reinforced_chest',
                 amount: 1,
-                nbt: `{display:{Name:'[{"text":"End Botanical Survey"}]',Lore:['[{"text":"A collection of botanical samples from the End.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_botanical_survey_end_combo"}}`
+                nbt: `{display:{Lore:['[{"text":"A collection of botanical samples from the End.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_botanical_survey_end_combo"}}`
             },
             level: 0,
             maxStock: 5,
@@ -66,7 +66,7 @@ onEvent('recipes', (event) => {
                 type: 'ITEM',
                 id: 'pneumaticcraft:reinforced_chest',
                 amount: 1,
-                nbt: `{display:{Name:'[{"text":"The End Mineral Survey"}]',Lore:['[{"text":"A collection of minerals from the The End.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_the_end_combo"}}`
+                nbt: `{display:{Lore:['[{"text":"A collection of minerals from the The End.","color":"gold"}]']},BlockEntityTag:{LootTable:"enigmatica:chests/amadron_mineral_survey_the_end_combo"}}`
             },
             level: 0,
             maxStock: 5,


### PR DESCRIPTION
Quite simply: the returned chest having a name is a pain in the butt for automation, each time someone complains they will just get told to re-use the returned item to make the new set of survey tools, but early on (in the low-automation phase) making a setup capable of properly recycling them is just too much of a hastle, especially when using several dimensions.

This pull request removes the name of the returned chests, so once you place it down & mine it the nbt essentially resets:
![Screen Shot 2022-06-02 at 13 32 30](https://user-images.githubusercontent.com/3179271/171620340-6c8a3313-4842-4789-84c9-3431f7158932.png)

I have tried to see if i could modify the loot table for the chest to not keep the name if the name is set to one of these, but minecraft seems to lack that functionality, and i don't have the infrastructure in place to check for all mod predicates.

Another attempt involved trying to use the mechanic that sets the loot table on place & nullify the name from there, but it seems that the name from the item gets put on the block after the block entity tag already has been processed:
`/data modify block ~ ~ ~ Items[0].tag.BlockEntityTag.CustomName set value '{"text":"No"}'`
(this does not show up as the name as long as the item itself already has a name ^)

Therefore the most painless solution would be to just not give the chest a name, and rely on the lore field(s),
this way the mined chests match the nbt of freshly crafted ones. (since lore doesn't carry over to the block)

🥔 

Q: but what if people can't find those chests in the storage system if their name isn't unique?
A: they can simply search on the #lore or just look through them, you're unlikely to have more than a few reinforced ones.

Q: just spend some time on automating it for all of the dimensions.
A: since its manual you're unlikely to be using it a lot, so by the time you unlock stuff to make recycling easier its a pain.

Q: why no recipe to reset the name instead?
A: [you wouldn't need to reset the name if it didn't have one to begin with.](https://xyproblem.info/)