### PR TITLE
Mention that the refined silk touch doesn't drop spawners

### DIFF
--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -171,6 +171,10 @@ onEvent('item.tooltip', (event) => {
         {
             items: ['kubejs:monster_mash'],
             text: [Text.of(`...It caught on in a flash...`).red()]
+        },
+        {
+            items: ['refinedstorage:silk_touch_upgrade'],
+            text: [Text.of('Does not work on spawners.').red()]
         }
     ];
 


### PR DESCRIPTION
Stuff like grass blocks works just fine, but it destroys any spawners, i would have rather known about this **bug** beforehand:
![2022-06-04_14 48 15](https://user-images.githubusercontent.com/3179271/171999757-acb14dbb-071e-4b93-a17f-03193008e369.png)
