### PR TITLE
Fix Building Gadgets Blacklists

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/buildinggadgets/blacklists.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/buildinggadgets/blacklists.js
@@ -1,6 +1,6 @@
 onEvent('block.tags', (event) => {
     // Documentation: https://github.com/Direwolf20-MC/BuildingGadgets/tree/master/src/main/resources/data/buildinggadgets/tags/blocks/blacklist
-    // Generic affects all tools
+
     const blocks = [
         'immersiveengineering:alloy_smelter',
         'immersiveengineering:arc_furnace',
@@ -29,5 +29,7 @@ onEvent('block.tags', (event) => {
         'immersivepetroleum:pumpjack',
         'xnet:facade'
     ];
-    event.get('buildinggadgets:blacklist/generic').add(blocks);
+    event.get('buildinggadgets:blacklist/building').add(blocks);
+    event.get('buildinggadgets:blacklist/copy_paste').add(blocks);
+    event.get('buildinggadgets:blacklist/exchanging').add(blocks);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -44,17 +44,7 @@ onEvent('server.datapack.high_priority', (event) => {
         'bloodmagic:alchemytable',
         'bloodmagic:soulforge',
         'bloodmagic:alchemicalreactionchamber',
-        'bloodmagic:incensealtar',
-        'bloodmagic:accelerationrune',
-        'bloodmagic:orbcapacityrune',
-        'bloodmagic:bettercapacityrune',
-        'bloodmagic:altarcapacityrune',
-        'bloodmagic:dislocationrune',
-        'bloodmagic:selfsacrificerune',
-        'bloodmagic:sacrificerune',
-        'bloodmagic:speedrune',
-        'bloodmagic:chargingrune',
-        'bloodmagic:blankrune'
+        'bloodmagic:incensealtar'
     ];
     // Requires creation Master Blood Orb to place outside of Undergarden
     restricted_blood_magic_blocks.forEach((block) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/tags/blocks/buildinggadgets/blacklists.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/tags/blocks/buildinggadgets/blacklists.js
@@ -1,6 +1,6 @@
 onEvent('block.tags', (event) => {
     // Documentation: https://github.com/Direwolf20-MC/BuildingGadgets/tree/master/src/main/resources/data/buildinggadgets/tags/blocks/blacklist
-    // Generic affects all tools
+
     const blocks = [
         'bloodmagic:altar',
         'bloodmagic:alchemytable',
@@ -10,16 +10,6 @@ onEvent('block.tags', (event) => {
         'bloodmagic:soulforge',
         'bloodmagic:alchemicalreactionchamber',
         'bloodmagic:incensealtar',
-        'bloodmagic:accelerationrune',
-        'bloodmagic:orbcapacityrune',
-        'bloodmagic:bettercapacityrune',
-        'bloodmagic:altarcapacityrune',
-        'bloodmagic:dislocationrune',
-        'bloodmagic:selfsacrificerune',
-        'bloodmagic:sacrificerune',
-        'bloodmagic:speedrune',
-        'bloodmagic:chargingrune',
-        'bloodmagic:blankrune',
         'eidolon:soul_enchanter',
         'occultism:sacrificial_bowl',
         'occultism:chalk_glyph_white',
@@ -27,5 +17,7 @@ onEvent('block.tags', (event) => {
         'occultism:chalk_glyph_red',
         'occultism:chalk_glyph_gold'
     ];
-    event.get('buildinggadgets:blacklist/generic').add(blocks);
+    event.get('buildinggadgets:blacklist/building').add(blocks);
+    event.get('buildinggadgets:blacklist/copy_paste').add(blocks);
+    event.get('buildinggadgets:blacklist/exchanging').add(blocks);
 });


### PR DESCRIPTION
Resolves #4967
Also removes BM runes from the mix to facilitate altar building. The altar block itself remains blacklisted.