### PR TITLE
[Expert] Unify Masterful Machinery Inputs

### DIFF
--- a/config/masterful_machinery/controllers/enigmatic_tree_of_life.json
+++ b/config/masterful_machinery/controllers/enigmatic_tree_of_life.json
@@ -15,7 +15,7 @@
             "textureOverride": "botania:block/livingwood_planks",
             "name": "Fluid",
             "id": "fluid",
-            "data": { "capacity": 2147483647 }
+            "data": { "capacity": 512000 }
         },
         {
             "type": "masterfulmachinery:items",

--- a/config/masterful_machinery/controllers/enigmatic_tree_of_life.json
+++ b/config/masterful_machinery/controllers/enigmatic_tree_of_life.json
@@ -15,7 +15,7 @@
             "textureOverride": "botania:block/livingwood_planks",
             "name": "Fluid",
             "id": "fluid",
-            "data": { "capacity": 512000 }
+            "data": { "capacity": 2147483647 }
         },
         {
             "type": "masterfulmachinery:items",

--- a/config/masterful_machinery/controllers/gaia_reactor.json
+++ b/config/masterful_machinery/controllers/gaia_reactor.json
@@ -7,35 +7,26 @@
             "type": "masterfulmachinery:items",
             "name": "Item",
             "id": "item",
-            "data": {
-                "rows": 6,
-                "columns": 5
-            }
+            "data": { "rows": 6, "columns": 5 }
         },
         {
             "type": "masterfulmachinery:energy",
             "name": "FE",
             "id": "energy",
-            "data": {
-                "capacity": 500000000
-            }
+            "data": { "capacity": 500000000 }
         },
         {
             "type": "masterfulmachinery:fluids",
             "name": "Fluid",
             "id": "fluid",
-            "data": {
-                "capacity": 512000
-            }
+            "data": { "capacity": 2147483647 }
         },
         {
             "type": "masterfulmachinery:botania_mana",
             "textureOverride": "mekanism:block/block_bronze",
             "name": "Mana",
             "id": "mana",
-            "data": {
-                "capacity": 1000000
-            }
+            "data": { "capacity": 1000000 }
         },
         {
             "type": "masterfulmachinery:pncr_pressure",

--- a/config/masterful_machinery/controllers/gaia_reactor.json
+++ b/config/masterful_machinery/controllers/gaia_reactor.json
@@ -7,26 +7,35 @@
             "type": "masterfulmachinery:items",
             "name": "Item",
             "id": "item",
-            "data": { "rows": 6, "columns": 5 }
+            "data": {
+                "rows": 6,
+                "columns": 5
+            }
         },
         {
             "type": "masterfulmachinery:energy",
             "name": "FE",
             "id": "energy",
-            "data": { "capacity": 500000000 }
+            "data": {
+                "capacity": 500000000
+            }
         },
         {
             "type": "masterfulmachinery:fluids",
             "name": "Fluid",
             "id": "fluid",
-            "data": { "capacity": 2147483647 }
+            "data": {
+                "capacity": 512000
+            }
         },
         {
             "type": "masterfulmachinery:botania_mana",
             "textureOverride": "mekanism:block/block_bronze",
             "name": "Mana",
             "id": "mana",
-            "data": { "capacity": 1000000 }
+            "data": {
+                "capacity": 1000000
+            }
         },
         {
             "type": "masterfulmachinery:pncr_pressure",

--- a/config/masterful_machinery/controllers/industrial_deuterium_plant.json
+++ b/config/masterful_machinery/controllers/industrial_deuterium_plant.json
@@ -16,26 +16,26 @@
             "name": "Fluid",
             "id": "fluid",
             "data": {
-                "capacity": 2147483647
+                "capacity": 100000
             }
         },
         {
-            "type": "masterfulmachinery:create_rotation",
-            "name": "Pump Rotation",
-            "id": "spinny",
-            "data": {
-                "stress": 100
-            }
+          "type": "masterfulmachinery:create_rotation",
+          "name": "Pump Rotation",
+          "id": "spinny",
+          "data": {
+             "stress": 100
+          }
         },
         {
-            "type": "masterfulmachinery:pncr_pressure",
-            "name": "Cooling",
-            "id": "pressure",
-            "data": {
-                "volume": 100000,
-                "dangerPressure": 20,
-                "criticalPressure": 30
-            }
+          "type": "masterfulmachinery:pncr_pressure",
+          "name": "Cooling",
+          "id": "pressure",
+          "data": {
+            "volume": 100000,
+            "dangerPressure": 20,
+            "criticalPressure": 30
+          }
         }
     ]
 }

--- a/config/masterful_machinery/controllers/industrial_deuterium_plant.json
+++ b/config/masterful_machinery/controllers/industrial_deuterium_plant.json
@@ -16,26 +16,26 @@
             "name": "Fluid",
             "id": "fluid",
             "data": {
-                "capacity": 100000
+                "capacity": 2147483647
             }
         },
         {
-          "type": "masterfulmachinery:create_rotation",
-          "name": "Pump Rotation",
-          "id": "spinny",
-          "data": {
-             "stress": 100
-          }
+            "type": "masterfulmachinery:create_rotation",
+            "name": "Pump Rotation",
+            "id": "spinny",
+            "data": {
+                "stress": 100
+            }
         },
         {
-          "type": "masterfulmachinery:pncr_pressure",
-          "name": "Cooling",
-          "id": "pressure",
-          "data": {
-            "volume": 100000,
-            "dangerPressure": 20,
-            "criticalPressure": 30
-          }
+            "type": "masterfulmachinery:pncr_pressure",
+            "name": "Cooling",
+            "id": "pressure",
+            "data": {
+                "volume": 100000,
+                "dangerPressure": 20,
+                "criticalPressure": 30
+            }
         }
     ]
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
@@ -16,7 +16,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:shulk_me_not', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:rosa_arcana', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:dandelifeon', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}botanical_mastery_shard`
@@ -35,7 +35,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'astralsorcery:marble_bricks', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { tag: 'astralsorcery:crystals/attuned', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'astralsorcery:liquid_starlight', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}astronomy_mastery_shard`
@@ -53,7 +53,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'atum:linen_bandage', count: 33 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:rune_weakness', count: 9 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:anchor_plate', count: 9 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}alchemy_mastery_shard`
@@ -77,7 +77,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_ritual_kit', count: 10 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_chalk_set', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'bloodmagic:life_essence_fluid', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}ritual_mastery_shard`
@@ -95,7 +95,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:rail', count: 64 } },
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:activator_rail', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:aura_detector', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}aura_mastery_shard`
@@ -130,7 +130,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pressure_chamber', count: 1 } },
 
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'pneumaticcraft:lubricant', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}engineering_mastery_shard`
@@ -178,13 +178,15 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'fluxnetworks:flux_plug', count: 2 } },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'mekanismgenerators:tritium', amount: 12800 * 3000 }
+                    perTick: true,
+                    data: { fluid: 'mekanismgenerators:tritium', amount: 12800 }
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'mekanismgenerators:deuterium', amount: 12800 * 3000 }
+                    perTick: true,
+                    data: { fluid: 'mekanismgenerators:deuterium', amount: 12800 }
                 },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 3000,
             id: `${id_prefix}energistics_mastery_shard`
@@ -204,7 +206,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'rsinfinitybooster:dimension_card', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_receiver', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_transmitter', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}dimensional_mastery_shard`
@@ -219,7 +221,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_meka_tool', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:teleporter', count: 5 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:portable_teleporter', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}battle_mastery_shard`
@@ -239,7 +241,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:mining_gadget_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:flux_bore_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pedestal_quarry', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}excavation_mastery_shard`
@@ -248,7 +250,7 @@ onEvent('recipes', (event) => {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'kubejs:culinary_mastery_shard', count: 1 } }],
             inputs: [
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:engineering_student_meals', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}culinary_mastery_shard`
@@ -278,7 +280,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:auto_crafting_halo', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:field_creator', count: 2 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:placer', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
+                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
             ],
             ticks: 60,
             id: `${id_prefix}automation_mastery_shard`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
@@ -16,7 +16,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:shulk_me_not', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:rosa_arcana', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:dandelifeon', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}botanical_mastery_shard`
@@ -35,7 +35,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'astralsorcery:marble_bricks', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { tag: 'astralsorcery:crystals/attuned', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'astralsorcery:liquid_starlight', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}astronomy_mastery_shard`
@@ -53,7 +53,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'atum:linen_bandage', count: 33 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:rune_weakness', count: 9 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:anchor_plate', count: 9 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}alchemy_mastery_shard`
@@ -77,7 +77,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_ritual_kit', count: 10 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_chalk_set', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'bloodmagic:life_essence_fluid', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}ritual_mastery_shard`
@@ -95,7 +95,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:rail', count: 64 } },
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:activator_rail', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:aura_detector', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}aura_mastery_shard`
@@ -130,7 +130,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pressure_chamber', count: 1 } },
 
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'pneumaticcraft:lubricant', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}engineering_mastery_shard`
@@ -178,15 +178,13 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'fluxnetworks:flux_plug', count: 2 } },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'mekanismgenerators:tritium', amount: 12800 }
+                    data: { fluid: 'mekanismgenerators:tritium', amount: 12800 * 3000 }
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'mekanismgenerators:deuterium', amount: 12800 }
+                    data: { fluid: 'mekanismgenerators:deuterium', amount: 12800 * 3000 }
                 },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 3000,
             id: `${id_prefix}energistics_mastery_shard`
@@ -206,7 +204,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'rsinfinitybooster:dimension_card', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_receiver', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_transmitter', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}dimensional_mastery_shard`
@@ -221,7 +219,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_meka_tool', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:teleporter', count: 5 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:portable_teleporter', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}battle_mastery_shard`
@@ -241,7 +239,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:mining_gadget_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:flux_bore_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pedestal_quarry', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}excavation_mastery_shard`
@@ -250,7 +248,7 @@ onEvent('recipes', (event) => {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'kubejs:culinary_mastery_shard', count: 1 } }],
             inputs: [
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:engineering_student_meals', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}culinary_mastery_shard`
@@ -280,7 +278,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:auto_crafting_halo', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:field_creator', count: 2 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:placer', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}automation_mastery_shard`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
@@ -19,13 +19,11 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'pneumaticcraft:memory_essence', amount: 16000 }
+                    data: { fluid: 'pneumaticcraft:memory_essence', amount: 16000 * 300 }
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'astralsorcery:liquid_starlight', amount: 1000 }
+                    data: { fluid: 'astralsorcery:liquid_starlight', amount: 1000 * 300 }
                 },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
@@ -19,11 +19,13 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'pneumaticcraft:memory_essence', amount: 16000 * 300 }
+                    perTick: true,
+                    data: { fluid: 'pneumaticcraft:memory_essence', amount: 16000 }
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'astralsorcery:liquid_starlight', amount: 1000 * 300 }
+                    perTick: true,
+                    data: { fluid: 'astralsorcery:liquid_starlight', amount: 1000 }
                 },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/industrial_deuterium_plant.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/industrial_deuterium_plant.js
@@ -8,7 +8,8 @@ onEvent('recipes', (event) => {
             outputs: [
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'mekanismgenerators:deuterium', amount: 640 * 4000 }
+                    perTick: true,
+                    data: { fluid: 'mekanismgenerators:deuterium', amount: 640 }
                 }
             ],
             inputs: [
@@ -19,16 +20,21 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'emendatusenigmatica:molten_sulfur', amount: 10 * 4000 }
-                },
-                {
-                    type: 'masterfulmachinery:pncr_pressure',
                     perTick: true,
-                    data: { air: 100 }
+                    data: { fluid: 'emendatusenigmatica:molten_sulfur', amount: 10 }
                 },
                 {
-                    type: 'masterfulmachinery:create_rotation',
-                    data: { speed: 256 }
+                    type: "masterfulmachinery:pncr_pressure",
+                    perTick: true,
+                    data:{
+                        air: 100
+                    }
+                },
+                {
+                    type: "masterfulmachinery:create_rotation",
+                    data:{
+                        speed: 256
+                    }
                 }
             ],
             ticks: 4000,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/industrial_deuterium_plant.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/industrial_deuterium_plant.js
@@ -8,8 +8,7 @@ onEvent('recipes', (event) => {
             outputs: [
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'mekanismgenerators:deuterium', amount: 640 }
+                    data: { fluid: 'mekanismgenerators:deuterium', amount: 640 * 4000 }
                 }
             ],
             inputs: [
@@ -20,21 +19,16 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'emendatusenigmatica:molten_sulfur', amount: 10 }
+                    data: { fluid: 'emendatusenigmatica:molten_sulfur', amount: 10 * 4000 }
                 },
                 {
-                    type: "masterfulmachinery:pncr_pressure",
+                    type: 'masterfulmachinery:pncr_pressure',
                     perTick: true,
-                    data:{
-                        air: 100
-                    }
+                    data: { air: 100 }
                 },
                 {
-                    type: "masterfulmachinery:create_rotation",
-                    data:{
-                        speed: 256
-                    }
+                    type: 'masterfulmachinery:create_rotation',
+                    data: { speed: 256 }
                 }
             ],
             ticks: 4000,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/shaped.js
@@ -125,7 +125,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'immersiveengineering:hempcrete',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'pneumaticcraft:huge_tank',
+                C: 'industrialforegoing:supreme_black_hole_tank',
                 D: 'xnet:advanced_connector_green',
                 E: 'mekanism:hdpe_sheet'
             },
@@ -137,7 +137,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'immersiveengineering:hempcrete',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'pneumaticcraft:huge_tank',
+                C: 'industrialforegoing:supreme_black_hole_tank',
                 D: 'xnet:advanced_connector_red',
                 E: 'mekanism:hdpe_sheet'
             },
@@ -184,7 +184,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'pneumaticcraft:huge_tank',
+                C: 'industrialforegoing:supreme_black_hole_tank',
                 D: 'xnet:advanced_connector_green',
                 E: '#forge:ingots/terrasteel'
             },
@@ -219,7 +219,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'pneumaticcraft:huge_tank',
+                C: 'industrialforegoing:supreme_black_hole_tank',
                 D: 'xnet:advanced_connector_green',
                 E: '#forge:circuits/elite'
             },
@@ -231,7 +231,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'pneumaticcraft:huge_tank',
+                C: 'industrialforegoing:supreme_black_hole_tank',
                 D: 'xnet:advanced_connector_red',
                 E: '#forge:circuits/elite'
             },
@@ -297,13 +297,12 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'masterfulmachinery:enigmatic_tree_of_life_fluid_port_fluids_input',
-            pattern: ['ABA', 'CEC', 'ADA'],
+            pattern: ['ABA', 'BCB', 'ADA'],
             key: {
                 A: 'mythicbotany:yggdrasil_branch',
-                B: 'create:copper_valve_handle',
-                C: 'create:fluid_pipe',
-                D: 'botania:green_petal_block',
-                E: 'create:fluid_valve'
+                B: 'mekanism:ultimate_mechanical_pipe',
+                C: 'industrialforegoing:supreme_black_hole_tank',
+                D: 'botania:green_petal_block'
             },
             id: `${id_prefix}enigmatic_tree_of_life_fluid_port_fluids_input`
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/shaped.js
@@ -125,7 +125,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'immersiveengineering:hempcrete',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
+                C: 'pneumaticcraft:huge_tank',
                 D: 'xnet:advanced_connector_green',
                 E: 'mekanism:hdpe_sheet'
             },
@@ -137,7 +137,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'immersiveengineering:hempcrete',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
+                C: 'pneumaticcraft:huge_tank',
                 D: 'xnet:advanced_connector_red',
                 E: 'mekanism:hdpe_sheet'
             },
@@ -184,7 +184,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
+                C: 'pneumaticcraft:huge_tank',
                 D: 'xnet:advanced_connector_green',
                 E: '#forge:ingots/terrasteel'
             },
@@ -219,7 +219,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
+                C: 'pneumaticcraft:huge_tank',
                 D: 'xnet:advanced_connector_green',
                 E: '#forge:circuits/elite'
             },
@@ -231,7 +231,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: '#forge:plates/steel',
                 B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
+                C: 'pneumaticcraft:huge_tank',
                 D: 'xnet:advanced_connector_red',
                 E: '#forge:circuits/elite'
             },
@@ -297,12 +297,13 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'masterfulmachinery:enigmatic_tree_of_life_fluid_port_fluids_input',
-            pattern: ['ABA', 'BCB', 'ADA'],
+            pattern: ['ABA', 'CEC', 'ADA'],
             key: {
                 A: 'mythicbotany:yggdrasil_branch',
-                B: 'mekanism:ultimate_mechanical_pipe',
-                C: 'industrialforegoing:supreme_black_hole_tank',
-                D: 'botania:green_petal_block'
+                B: 'create:copper_valve_handle',
+                C: 'create:fluid_pipe',
+                D: 'botania:green_petal_block',
+                E: 'create:fluid_valve'
             },
             id: `${id_prefix}enigmatic_tree_of_life_fluid_port_fluids_input`
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/stellar_neutron_activator.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/stellar_neutron_activator.js
@@ -8,7 +8,8 @@ onEvent('recipes', (event) => {
             outputs: [
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'mekanismgenerators:tritium', amount: 640 * 4000 }
+                    perTick: true,
+                    data: { fluid: 'mekanismgenerators:tritium', amount: 640 }
                 }
             ],
             inputs: [
@@ -24,7 +25,8 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    data: { fluid: 'minecraft:water', amount: 64000 * 4000 }
+                    perTick: true,
+                    data: { fluid: 'minecraft:water', amount: 64000 }
                 }
             ],
             ticks: 4000,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/stellar_neutron_activator.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/stellar_neutron_activator.js
@@ -8,8 +8,7 @@ onEvent('recipes', (event) => {
             outputs: [
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'mekanismgenerators:tritium', amount: 640 }
+                    data: { fluid: 'mekanismgenerators:tritium', amount: 640 * 4000 }
                 }
             ],
             inputs: [
@@ -25,8 +24,7 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'masterfulmachinery:fluids',
-                    perTick: true,
-                    data: { fluid: 'minecraft:water', amount: 64000 }
+                    data: { fluid: 'minecraft:water', amount: 64000 * 4000 }
                 }
             ],
             ticks: 4000,


### PR DESCRIPTION
All FE, Astral Starlight, and Air inputs remain per tick. Everything else is moved over to take the full input in 1 shot.

This necesarily meant increasing the size of several fluid inputs so they can accomodate the larger volumes. Existing structures will update without issue.

Since the old recipes were built around the limited size of the tanks, the recipes are also adjusted to accomodate the large size. Generally swapping in a Supreme Black Hole Tank in place of whatever was there before. 