### PR TITLE
[Expert] Standardize MM machine inputs and document in JEI/Quests

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -529,8 +529,9 @@
 			x: 0.5d
 			y: -5.5d
 			shape: "gear"
-			description: ["By transmuting the latent energies in Life Essence, the Wicked Altar is capable of infusing specially prepared materials with great power."
-			""
+			description: [
+				"By transmuting the latent energies in Life Essence, the Wicked Altar is capable of infusing specially prepared materials with great power."
+				""
 				"================================================================="
 				""
 				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
@@ -540,7 +541,8 @@
 				"● Astral Starlight is consumed per tick"
 				"● Fluids are consumed or created per tick"
 				"● Items are consumed or created at the end of a craft"
-				"● Mana is consumed at the start of a craft or created at the end"]
+				"● Mana is consumed at the start of a craft or created at the end"
+			]
 			dependencies: ["06A20E7EA36392CB"]
 			min_width: 400
 			id: "03B61EC7DD43C550"

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -529,8 +529,20 @@
 			x: 0.5d
 			y: -5.5d
 			shape: "gear"
-			description: ["By transmuting the latent energies in Life Essence, the Wicked Altar is capable of infusing specially prepared materials with great power. "]
+			description: ["By transmuting the latent energies in Life Essence, the Wicked Altar is capable of infusing specially prepared materials with great power."
+			""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"]
 			dependencies: ["06A20E7EA36392CB"]
+			min_width: 400
 			id: "03B61EC7DD43C550"
 			tasks: [{
 				id: "7C9DF703B05DF144"

--- a/config/ftbquests/quests/chapters/magic__master.snbt
+++ b/config/ftbquests/quests/chapters/magic__master.snbt
@@ -509,9 +509,21 @@
 			description: [
 				"By storing Starlight eddies in a massive crystalline battery, the Iridescent Altar may be made to work faster and at any time of day."
 				""
-				"Advanced control circuits ensure the rituals are handled appropriately and without oversight. "
+				"Advanced control circuits ensure the rituals are handled appropriately and without oversight."
+				""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"
 			]
 			dependencies: ["2D6DDD000FC99514"]
+			min_width: 400
 			id: "0D5EFF4C653C3DD9"
 			tasks: [{
 				id: "11A8B09E6B1A0DFB"
@@ -524,11 +536,23 @@
 			y: 4.0d
 			shape: "gear"
 			description: [
-				"A massive starlight cooled construct used to extract the very essence from the Guardian trapped within. "
+				"A massive starlight cooled construct used to extract the very essence from the Guardian trapped within."
 				""
 				"Though energy intensive, the machine can renewably generate Gaia Spirits needed by higher magics."
+				""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"
 			]
 			dependencies: ["457523FA165A5A0B"]
+			min_width: 400
 			id: "226F249D3F4A9258"
 			tasks: [{
 				id: "59FF57ADF3D44FA2"

--- a/config/ftbquests/quests/chapters/tech_t3.snbt
+++ b/config/ftbquests/quests/chapters/tech_t3.snbt
@@ -388,8 +388,20 @@
 				"Two air supplies are required to run this machine. The High-Pressure Input requires greater than 11 bar to begin functioning while the Assembly Controller needs 5 bar and may be accessed from below. "
 				""
 				"This machine will still function for all regular Assembly Table crafts as well by placing the inputs in the crate in the back. All outputs will be retrieved from this same crate."
+				""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"
 			]
 			dependencies: ["71D581C742D17CA4"]
+			min_width: 400
 			id: "76EDB33FBF318FB4"
 			tasks: [{
 				id: "33104A6845FE9370"
@@ -402,11 +414,23 @@
 			y: 7.0d
 			shape: "gear"
 			description: [
-				"Though based on simple technologies, this massive machine can churn out industrial quantities of Deuterium quickly enough to meet the needs of a Fusion Reactor.  "
+				"Though based on simple technologies, this massive machine can churn out industrial quantities of Deuterium quickly enough to meet the needs of a Fusion Reactor."
 				""
-				"Note: This multiblock expects water underneath it with the legs submerged right up to the base of the platform. As such, it is best built as an offshore platform. Be wary of kelp and other plant life, as its presence will break the structure "
+				"Note: This multiblock expects water underneath it with the legs submerged right up to the base of the platform. As such, it is best built as an offshore platform. Be wary of kelp and other plant life, as its presence will break the structure."
+				""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"
 			]
 			dependencies: ["40204EBF03AD725E"]
+			min_width: 400
 			id: "5E61BE9DA7DA1FEC"
 			tasks: [{
 				id: "621697B1EC42D23F"

--- a/config/ftbquests/quests/chapters/tech_t3.snbt
+++ b/config/ftbquests/quests/chapters/tech_t3.snbt
@@ -369,8 +369,22 @@
 			x: 4.0d
 			y: 7.0d
 			shape: "gear"
-			description: ["A fusion of technology and magic, the Stellar Neutron Activator is capable of producing enormous quantities of Tritium continuously, though the process requires enormous quantities of mana and energy to extract it from water."]
+			description: [
+				"A fusion of technology and magic, the Stellar Neutron Activator is capable of producing enormous quantities of Tritium continuously, though the process requires enormous quantities of mana and energy to extract it from water."
+				""
+				"================================================================="
+				""
+				"Note that the recipes shown in JEI don't accurately display whether any given input is per tick or all at once. For simplicity, all recipes for all Masterful Machines have been standardized under the following rule set:"
+				""
+				"● Forge Energy is consumed per tick"
+				"● Pneumatic Air is consumed per tick and must be over 10 Bar"
+				"● Astral Starlight is consumed per tick"
+				"● Fluids are consumed or created per tick"
+				"● Items are consumed or created at the end of a craft"
+				"● Mana is consumed at the start of a craft or created at the end"
+			]
 			dependencies: ["40204EBF03AD725E"]
+			min_width: 400
 			id: "5A772150FF638680"
 			tasks: [{
 				id: "2124E28BB47D675C"

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -466,12 +466,27 @@ onEvent('jei.information', (event) => {
         },
         {
             items: [/masterfulmachinery:\w+_controller/],
+            text: [`This structure will be difficult to build by hand.`]
+        },
+        {
+            items: [/masterfulmachinery:\w+_controller/],
             text: [
-                `This structure will be difficult to build by hand.`,
-                ` `,
                 `Use the included Building Gadgets patterns found in the "building_gadgets_patterns" folder of Enigmatica 6 instance folder.`,
                 ` `,
                 'May be rotated, but not mirrored.'
+            ]
+        },
+
+        {
+            items: [/masterfulmachinery:\w+_controller/],
+            text: [
+                'A note on the values shown in recipes for these machines:',
+                `● Forge Energy is consumed per tick`,
+                `● Pneumatic Air is consumed per tick and must be over 10 bar`,
+                `● Astral Starlight is consumed per tick`,
+                `● Fluids are consumed or created per tick`,
+                `● Items are consumed or created at the end of a craft`,
+                `● Mana is consumed at the start of a craft or created at the end`
             ]
         },
         {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/auto_iridescent_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/auto_iridescent_altar.js
@@ -510,8 +510,11 @@ onEvent('recipes', (event) => {
                     type: 'masterfulmachinery:items',
                     data: { item: 'astralsorcery:illumination_powder', count: 4 }
                 },
+                {
+                    type: 'masterfulmachinery:items',
+                    data: { item: 'industrialforegoing:ether_gas_bucket', count: 1 }
+                },
 
-                { type: 'masterfulmachinery:fluids', data: { fluid: 'industrialforegoing:ether_gas', amount: 1000 } },
                 { type: 'masterfulmachinery:energy', perTick: true, data: { amount: 500000 } },
                 { type: 'masterfulmachinery:astral_starlight', perTick: true, data: { amount: 50 } }
             ],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
@@ -16,7 +16,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:shulk_me_not', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:rosa_arcana', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { item: 'botania:dandelifeon', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}botanical_mastery_shard`
@@ -35,7 +35,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'astralsorcery:marble_bricks', count: 4 } },
                 { type: 'masterfulmachinery:items', data: { tag: 'astralsorcery:crystals/attuned', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'astralsorcery:liquid_starlight', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}astronomy_mastery_shard`
@@ -53,7 +53,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'atum:linen_bandage', count: 33 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:rune_weakness', count: 9 } },
                 { type: 'masterfulmachinery:items', data: { item: 'darkutils:anchor_plate', count: 9 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}alchemy_mastery_shard`
@@ -77,7 +77,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_ritual_kit', count: 10 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:artisinal_chalk_set', count: 10 } },
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'bloodmagic:life_essence_fluid', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}ritual_mastery_shard`
@@ -95,7 +95,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:rail', count: 64 } },
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:activator_rail', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:aura_detector', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}aura_mastery_shard`
@@ -130,7 +130,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pressure_chamber', count: 1 } },
 
                 { type: 'masterfulmachinery:fluids', data: { fluid: 'pneumaticcraft:lubricant', amount: 64000 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}engineering_mastery_shard`
@@ -179,16 +179,16 @@ onEvent('recipes', (event) => {
                 {
                     type: 'masterfulmachinery:fluids',
                     perTick: true,
-                    data: { fluid: 'mekanismgenerators:tritium', amount: 12800 }
+                    data: { fluid: 'mekanismgenerators:tritium', amount: 25600 }
                 },
                 {
                     type: 'masterfulmachinery:fluids',
                     perTick: true,
-                    data: { fluid: 'mekanismgenerators:deuterium', amount: 12800 }
+                    data: { fluid: 'mekanismgenerators:deuterium', amount: 25600 }
                 },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 1500 } }
             ],
-            ticks: 3000,
+            ticks: 1500,
             id: `${id_prefix}energistics_mastery_shard`
         },
         {
@@ -206,7 +206,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'rsinfinitybooster:dimension_card', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_receiver', count: 8 } },
                 { type: 'masterfulmachinery:items', data: { item: 'refinedstorage:network_transmitter', count: 8 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}dimensional_mastery_shard`
@@ -221,7 +221,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_meka_tool', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:teleporter', count: 5 } },
                 { type: 'masterfulmachinery:items', data: { item: 'mekanism:portable_teleporter', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}battle_mastery_shard`
@@ -241,7 +241,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:mining_gadget_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:flux_bore_kit', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_pedestal_quarry', count: 4 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}excavation_mastery_shard`
@@ -250,7 +250,7 @@ onEvent('recipes', (event) => {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'kubejs:culinary_mastery_shard', count: 1 } }],
             inputs: [
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:engineering_student_meals', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}culinary_mastery_shard`
@@ -280,7 +280,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'botania:auto_crafting_halo', count: 1 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:field_creator', count: 2 } },
                 { type: 'masterfulmachinery:items', data: { item: 'naturesaura:placer', count: 1 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 500 } }
+                { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,
             id: `${id_prefix}automation_mastery_shard`

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/gaia_reactor.js
@@ -9,7 +9,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', chance: 1.0, data: { item: 'botania:life_essence', count: 8 } },
                 { type: 'masterfulmachinery:items', chance: 0.5, data: { item: 'botania:life_essence', count: 4 } },
                 { type: 'masterfulmachinery:items', chance: 0.25, data: { item: 'botania:life_essence', count: 2 } },
-                { type: 'masterfulmachinery:botania_mana', perTick: true, data: { amount: 9000 } }
+                { type: 'masterfulmachinery:botania_mana', data: { amount: 9000 * 300 } }
             ],
             inputs: [
                 {


### PR DESCRIPTION
Standardizes inputs across Masterful Machines so that it can be more clearly indicated to the player what to expect. 

● Forge Energy is consumed per tick
● Pneumatic Air is consumed per tick and must be over 10 Bar
● Astral Starlight is consumed per tick
● Fluids are consumed or created per tick
● Items are consumed or created at the end of a craft
● Mana is consumed at the start of a craft or created at the end

Updates all MM quests and adds a similar note in the Info tab for each MM controller 
![image](https://user-images.githubusercontent.com/9543430/172965843-3e7ca723-b13c-4392-8a76-d1ad358ac5b6.png)
