### PR TITLE
Allow waystones to be recycled by BM ARC scissors

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/waystones/waystone.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/waystones/waystone.js
@@ -1,0 +1,3 @@
+onEvent('item.tags', (event) => {
+    event.get('waystones:waystone').add(/waystones:(\w+_)?waystone$/);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/arc.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/arc.js
@@ -60,6 +60,30 @@ onEvent('recipes', (event) => {
             extraOutputs: [],
             consume: false,
             id: `${id_prefix}mana_diamond_block_from_dragonstone_block`
+        },
+        {
+            output: 'waystones:warp_stone',
+            input: '#waystones:waystone',
+            tool: '#bloodmagic:arc/reverter',
+            extraOutputs: [],
+            consume: false,
+            id: `${id_prefix}warp_stone_from_waystone`
+        },
+        {
+            output: 'waystones:warp_stone',
+            input: '#waystones:sharestone',
+            tool: '#bloodmagic:arc/reverter',
+            extraOutputs: [],
+            consume: false,
+            id: `${id_prefix}warp_stone_from_sharestone`
+        },
+        {
+            output: 'waystones:warp_stone',
+            input: 'waystones:portstone',
+            tool: '#bloodmagic:arc/reverter',
+            extraOutputs: [],
+            consume: false,
+            id: `${id_prefix}warp_stone_from_portstone`
         }
 
         /*,


### PR DESCRIPTION
![Screen Shot 2022-06-13 at 10 28 53](https://user-images.githubusercontent.com/3179271/173319438-e6297223-5fba-4279-a38c-641357da702d.png)

You spawn with one, but most importantly (& like other valuables) you can find a lot of them while exploring.

This is fine for when you're playing solo, but when you play in a team you have to tpa every teammate to a freshly placed waystone when you place/move it so they can rightclick it, sharestones however use color channels.

With this pull request you can recycle all the waystone mod blocks that contain a purple warp stone.

Recycling is gated after the point where you can make warp stones natively. (tier 3 blood altar)

I have considered the sawmill (like the dimensional shards) but it felt unsafe to stick stone in there, as well as the create crushing wheels but that felt way too early.

**TLDR** makes waystones worth collecting when playing in a team ^-^