### PR TITLE
[Expert] Reduce mana/blood cost of dislocation runes

### DIFF
--- a/config/ftbquests/quests/chapters/blood_magic_wip.snbt
+++ b/config/ftbquests/quests/chapters/blood_magic_wip.snbt
@@ -364,9 +364,9 @@
 			rewards: [{
 				id: "00000000000008C6"
 				type: "item"
-				title: "Speed Rune"
-				item: "bloodmagic:speedrune"
-				count: 2
+				title: "Displacement Rune"
+				item: "bloodmagic:dislocationrune"
+				count: 4
 			}]
 		}
 		{

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -447,14 +447,14 @@ onEvent('recipes', (event) => {
             inputs: [
                 'bloodmagic:blankrune',
                 'quark:blue_rune',
-                'bloodmagic:infusedslate',
+                'bloodmagic:reinforcedslate',
                 'ars_nouveau:glyph_extract',
-                'bloodmagic:infusedslate',
+                'bloodmagic:reinforcedslate',
                 'kubejs:cutting_essence',
                 'quark:blue_rune',
-                'bloodmagic:infusedslate',
+                'bloodmagic:reinforcedslate',
                 'ars_nouveau:glyph_accelerate',
-                'bloodmagic:infusedslate'
+                'bloodmagic:reinforcedslate'
             ],
             mana: 64000,
             output: 'bloodmagic:dislocationrune',


### PR DESCRIPTION
These are required to get the most out of the recent pre-WoS LP automation.

Doesn't change their gating at all, but by moving to an earlier rune and cutting the mana cost to craft, they'll be more accessible, adding value to actually setting up that automation.

Also changes BM quests to give 4 displacement runes instead of 2 speed runes. Ultimately, I think these are a more appropriate reward. 