### PR TITLE
`ci` fix kubejs error detection script (`catnip_larva` slipped through the cracks)

### DIFF
--- a/.github/actions/ci/log-kubejs-warnings.js
+++ b/.github/actions/ci/log-kubejs-warnings.js
@@ -24,4 +24,5 @@ warnings.forEach(warning => {
     console.log(`::warning::${warning}`);
 });
 
-process.exit(warnings.length === 0 ? 0 : 1);
+// return with exit code 1 for any warning amount
+process.exit(Math.min(1, warnings.length));

--- a/.github/actions/ci/log-kubejs-warnings.js
+++ b/.github/actions/ci/log-kubejs-warnings.js
@@ -2,18 +2,26 @@
 // and determining whether it contained errors or not.
 
 const fs = require('fs');
-
 const server = fs.readFileSync('logs/kubejs/server.txt', 'utf-8');
 
-let code = 0;
+let warnings = [];
 
 server.split(/\r?\n/).forEach((line) => {
-    if (line.includes('[ERR  ] Error') && !line.includes('shadows.menu.PackMenuClient')) {
-        console.log(`::warning::${line}`);
-        code = 1;
-    } else if (line.includes('[ERR  ]') || line.includes('[WARN ]')) {
-        console.log(line);
+
+    // the 2nd reload causes this error, avoid reporting this
+    if (line.includes('shadows.menu.PackMenuClient')) return;
+
+    // get the log level from this line, expected values: [ undefined, INFO, WARN, ERR ]
+    const in_brackets = line.match(/\[\d{2}:\d{2}:\d{2}] \[([A-Z\s]+)]/)?.[1];
+
+    switch (in_brackets) {
+        case 'ERR  ': warnings.push(line);
+        case 'WARN ': console.log(line);
     }
 });
 
-process.exit(code);
+warnings.forEach(warning => {
+    console.log(`::warning::${warning}`);
+});
+
+process.exit(warnings.length === 0 ? 0 : 1);

--- a/.github/actions/ci/patches/kubejs.patch
+++ b/.github/actions/ci/patches/kubejs.patch
@@ -11,6 +11,19 @@ index 8b9f4a1d..9a38b65d 100644
  	group = project.maven_group
  	archivesBaseName = project.archives_base_name
  
+diff --git a/common/src/main/java/dev/latvian/kubejs/recipe/RecipeEventJS.java b/common/src/main/java/dev/latvian/kubejs/recipe/RecipeEventJS.java
+index 46e32fe8..639229b8 100644
+--- a/common/src/main/java/dev/latvian/kubejs/recipe/RecipeEventJS.java
++++ b/common/src/main/java/dev/latvian/kubejs/recipe/RecipeEventJS.java
+@@ -369,7 +369,7 @@ public class RecipeEventJS extends EventJS {
+ 		ConsoleJS.SERVER.info("Added " + added.getValue() + " recipes, removed " + removed.getValue() + " recipes, modified " + modifiedRecipesCount.get() + " recipes, with " + failed.getValue() + " failed recipes and " + fallbacked.getValue() + " fall-backed recipes");
+ 		RecipeJS.itemErrors = false;
+ 
+-		if (CommonProperties.get().debugInfo) {
++		if (true) {
+ 			ConsoleJS.SERVER.info("======== Debug output of all added recipes ========");
+ 
+ 			for (RecipeJS r : addedRecipes) {
 diff --git a/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java b/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java
 index 907f306d..dc8f9fb6 100644
 --- a/common/src/main/java/dev/latvian/kubejs/script/ScriptManager.java

--- a/.github/actions/ci/start-server.js
+++ b/.github/actions/ci/start-server.js
@@ -1,6 +1,5 @@
 // This script is responsible for relaying logs from the Minecraft server instance to the console.
 
-const fsp = require('fs/promises');
 const { spawn } = require('child_process');
 
 const child = spawn(process.argv[2], [process.argv[3]]);
@@ -13,13 +12,6 @@ child.stderr.on('data', (data) => {
 child.stdout.on('data', (data) => {
     const line = data.toString();
     process.stdout.write(line);
-
-    // forge starting, at this point either serverstarter or instancesync made sure the kubejs common config exists.
-    if(line.includes('[cp.mo.mo.Launcher/MODLAUNCHER]: ModLauncher running')) {
-        fsp.readFile('kubejs/config/common.properties').then(data => {
-            fsp.writeFile('kubejs/config/common.properties', data.toString().replace('debugInfo=false', 'debugInfo=true'))
-        })
-    }
 
     if(line.includes('[minecraft/DedicatedServer]: Done (')) {
         console.log('requesting a kubejs export..');


### PR DESCRIPTION
Unfortunately niller beat me to it, #4996 got merged earlier in the day than expected, but here it is regardless:

KubeJS only outputs the added/modified/removed recipes while debug mode is on, unfortunately that also caused every warning to throw an err stacktrace which my detection script had trouble ignoring.

Now that patch files have gained a foothold in the ci, it can be used to get the recipe outputs without enabling debuginfo.

This means the ugly `ModLauncher running` hook can go, and allow the nodejs script to be simplified & cleaned.

Here is the output of it running on this branch, the builds for the pull request will likely succeed because of the merge:
![Screen Shot 2022-06-15 at 14 09 09](https://user-images.githubusercontent.com/3179271/173823648-8431180d-b417-4bac-a1ba-f7b3752999e4.png)

