### PR TITLE
Fix Coralstone tags to exclude basic and dead coralstone

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -183,12 +183,16 @@ onEvent('jei.information', (event) => {
             text: ['Obtained by killing Silk Moths which are spawned by Silk Moth Nests.']
         },
         {
-            items: [/upgrade_aquatic:\w+_coralstone$/],
-            text: ['Obtained by placing Coralstone next to living coral and waiting.']
+            items: [/upgrade_aquatic:(?!.*dead_coralstone|chiseled)(?=.*_coralstone$)/],
+            text: ['Obtained by placing Coralstone next to living coral and waiting. Requires Silk Touch to harvest.']
         },
         {
             items: ['upgrade_aquatic:coralstone'],
             text: ['Place next to living coral and wait for it to infuse.']
+        },
+        {
+            items: ['upgrade_aquatic:dead_coralstone'],
+            text: ['Obtained by breaking infused Coralstone without Silk Touch.']
         },
         {
             items: [

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/upgrade_aquatic/coralstone.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/upgrade_aquatic/coralstone.js
@@ -1,7 +1,12 @@
 onEvent('item.tags', (event) => {
-    event
-        .get('upgrade_aquatic:coralstone')
-        .add('upgrade_aquatic:coralstone')
-        .add(/upgrade_aquatic:\w+_coralstone$/);
-    event.get('upgrade_aquatic:coralstone/infused').add(/upgrade_aquatic:\w+_coralstone$/);
+    let items = [/upgrade_aquatic:\w+_coralstone$/, 'upgrade_aquatic:coralstone'];
+    event.get('upgrade_aquatic:coralstone').add(items);
+
+    items = [/upgrade_aquatic:\w+_coralstone$/];
+    let exceptions = [
+        'upgrade_aquatic:dead_coralstone',
+        'upgrade_aquatic:chiseled_coralstone',
+        'upgrade_aquatic:chiseled_dead_coralstone'
+    ];
+    event.get('upgrade_aquatic:coralstone/infused').add(items).remove(exceptions);
 });


### PR DESCRIPTION
Also cleans up the regex for coralstone JEI descriptions to exclude dead and chiseled coralstone, as those are obtained from infused coralstone, not via the infusion process.