### PR TITLE
Generate the modlist pretty much instantly

### DIFF
--- a/automation/node/modlist-generate.js
+++ b/automation/node/modlist-generate.js
@@ -2,59 +2,11 @@ const fs = require('fs');
 const axios = require('axios');
 
 const minecraftinstance_json = JSON.parse(fs.readFileSync(`${__dirname}/../../minecraftinstance.json`));
-const total_addons = minecraftinstance_json.installedAddons.length;
 
 // grab the name and the version for the markdown header from the pwsh settings
 const settings_ps1    = fs.readFileSync(`${__dirname}/../../automation/settings.ps1`).toString();
 const CLIENT_NAME     = settings_ps1.match(/\$CLIENT_NAME = "(.*)"/)[1];
 const MODPACK_VERSION = settings_ps1.match(/\$MODPACK_VERSION = "(.*)"/)[1];
-
-const readme = [`## ${CLIENT_NAME} - ${MODPACK_VERSION}`];
-console.log(readme[0]);
-
-const projects = [];
-
-function next(i) {
-    const installedAddon = minecraftinstance_json.installedAddons[i];
-    if (installedAddon) {
-
-        // this is the api behind the current modlist generator, not some custom one :)
-        const melanx_url = `https://curse.melanx.de/project/${installedAddon.addonID}`;
-
-        // log the progress to the console, old one does not.
-        console.log(`${i+1}/${total_addons}: ${melanx_url}`);
-
-        axios.get(melanx_url)
-            .then(response => {
-                const project = response.data;
-
-                // the api itself does not return the filename without an additional call, but we already know it.
-                project.file = {id: installedAddon.installedFile.id, name: installedAddon.installedFile.fileName};
-
-                console.log(project);
-                projects.push(project);
-
-                // {
-                //     project: 345779,
-                //     slug: 'plonk',
-                //     name: 'Plonk',
-                //     owner: 'BlueAgent',
-                //     summary: 'Place items down in the world',
-                //     distribution: true,
-                //     website: 'https://www.curseforge.com/minecraft/mc-mods/plonk',
-                //     thumbnail: 'https://media.forgecdn.net/avatars/230/201/637059414601035196.png',
-                //     file: { id: 3299406, name: 'plonk-1.16.5-9.0.8.jar' }
-                // }
-
-                next(i + 1); // process the next addon synchronously.
-            })
-            .catch(() => {
-                next(i); // the api has a tendency to be slow (or even time out), so in case of failure retry the current addon.
-            });
-    } else {
-        done(); // all the addons have been processed, finalize.
-    }
-}
 
 // match the sorting of MelanX/ModListCreator
 function by_project_name(project_a, project_b) {
@@ -63,14 +15,24 @@ function by_project_name(project_a, project_b) {
     return 0;
 }
 
-function done() {
-    projects.sort(by_project_name);
+// fire off just a single api call
+axios.get('https://curse.melanx.de/projects', {
+    data: minecraftinstance_json.installedAddons.map(installedAddon => installedAddon.addonID)
+}).then(response => {
+    const projects = Object.values(response.data).sort(by_project_name);
+    const file_for = []
 
-    projects.forEach(project => {
-        readme.push(`- [${project.file.name}](${project.website}/files/${project.file.id}) (by [${project.owner}](https://www.curseforge.com/members/${project.owner.toLowerCase()}/projects))`)
+    // we know the filename from minecraftinstance.json already. ^-^
+    minecraftinstance_json.installedAddons.forEach(installedAddon => {
+        file_for[installedAddon.addonID] = {id: installedAddon.installedFile.id, name: installedAddon.installedFile.fileName};
     });
 
-    fs.writeFileSync(`${__dirname}/../../MODLIST.md`, readme.join('\n') + '\n');
-}
+    const lines = [`## ${CLIENT_NAME} - ${MODPACK_VERSION}`];
 
-next(0); // all variables and functions have been defined above, now we can start it here.
+    projects.forEach(project => {
+        lines.push(`- [${file_for[project.project].name}](${project.website}/files/${file_for[project.project].id}) (by [${project.owner}](https://www.curseforge.com/members/${project.owner.toLowerCase()}/projects))`)
+    });
+
+    console.log(lines.join('\n'));
+    fs.writeFileSync(`${__dirname}/../../MODLIST.md`, lines.join('\n') + '\n');
+})


### PR DESCRIPTION
Thanks to https://github.com/ModdingX/ModListCreator/issues/11 there is now a bulk projects route available.

I have sent a pr for the java based modlist generator in order to benefit from it as well, but for now we have this.

It is my intention to see if i can further improve that generator so it can perhaps include file details directly in the bulk,
so perhaps one day we won't need this javascript file anymore and the ci can circle back around to moddingx's one. ^-^