### PR TITLE
Trim enchants available in Astral's Resplendent Prism

### DIFF
--- a/config/configswapper/expert/serverconfig/astralsorcery.toml
+++ b/config/configswapper/expert/serverconfig/astralsorcery.toml
@@ -1,3 +1,9 @@
 [crafting]
 	#Defines the state the starmetal ore will revert into when used up by a celestial crystal cluster. Obtain a valid state-string via '/astralsorcery serialize look' and look at the block you want to get. (Chat-Message can be copied)
 	starmetalRevertState = "kubejs:firmament"
+
+[registries]
+
+	[registries.amulet_enchantments]
+		#Defines a whitelist of which enchantments can be rolled and buffed by the enchantment-amulet. The higher the weight, the more likely that roll is selected.Format: <enchantment-registry-name>;<weight>
+		amulet_enchantments = ["minecraft:protection;5", "minecraft:respiration;2", "minecraft:sharpness;5", "minecraft:looting;2", "minecraft:sweeping;2", "minecraft:fortune;2", "minecraft:power;5", "minecraft:impaling;2", "minecraft:multishot;2", "gunswithoutroses:impact;5", "ars_nouveau:mana_regen;5", "ars_nouveau:mana_boost;5", "ensorcellation:magic_protection;5", "ensorcellation:exp_boost;5", "ensorcellation:gourmand;5", "ensorcellation:vitality;1", "ensorcellation:magic_edge;2", "ensorcellation:vorpal;2", "apotheosis:knowledge;2", "apotheosis:crescendo;2", "apotheosis:capturing;1"]

--- a/config/configswapper/normal/serverconfig/astralsorcery.toml
+++ b/config/configswapper/normal/serverconfig/astralsorcery.toml
@@ -1,3 +1,9 @@
 [crafting]
 	#Defines the state the starmetal ore will revert into when used up by a celestial crystal cluster. Obtain a valid state-string via '/astralsorcery serialize look' and look at the block you want to get. (Chat-Message can be copied)
 	starmetalRevertState = "minecraft:iron_ore"
+
+[registries]
+
+	[registries.amulet_enchantments]
+		#Defines a whitelist of which enchantments can be rolled and buffed by the enchantment-amulet. The higher the weight, the more likely that roll is selected.Format: <enchantment-registry-name>;<weight>
+		amulet_enchantments = ["minecraft:protection;5", "minecraft:respiration;2", "minecraft:sharpness;5", "minecraft:looting;2", "minecraft:sweeping;2", "minecraft:fortune;2", "minecraft:power;5", "minecraft:impaling;2", "minecraft:multishot;2", "gunswithoutroses:impact;5", "ars_nouveau:mana_regen;5", "ars_nouveau:mana_boost;5", "ensorcellation:magic_protection;5", "ensorcellation:exp_boost;5", "ensorcellation:gourmand;5", "ensorcellation:vitality;1", "ensorcellation:magic_edge;2", "ensorcellation:vorpal;2", "apotheosis:knowledge;2", "apotheosis:crescendo;2", "apotheosis:capturing;1"]

--- a/defaultconfigs/astralsorcery.toml
+++ b/defaultconfigs/astralsorcery.toml
@@ -8,7 +8,7 @@
 	#If set to 'true' anything that prevents mobspawning !by this mod!, will also prevent EVERY natural mobspawning of any mobtype. When set to 'false' it'll only stop monsters of type 'MONSTER' from spawning.
 	mobSpawningDenyAllTypes = false
 	#Features generating random ores in AstralSorcery will not spawn ores from mods listed here.
-	modidOreBlacklist = ["create", "eidolon", "occultism", "techreborn", "gregtech","mekanism","thermal","undergarden","immersiveengineering","tmechworks","mapperbase","minecraft","tconstruct","byg"]
+	modidOreBlacklist = ["create", "eidolon", "occultism", "techreborn", "gregtech", "mekanism", "thermal", "undergarden", "immersiveengineering", "tmechworks", "mapperbase", "minecraft", "tconstruct", "byg"]
 	#Set this to false to prevent players from being affected by entity-related colored lens effects.
 	doColoredLensesAffectPlayers = true
 
@@ -60,6 +60,8 @@
 	liquidStarlightDropInfusedWood = true
 	#Set this to false to disable the functionality that two crystals can merge and combine stats when thrown into liquid starlight.
 	liquidStarlightMergeCrystals = true
+	#Defines the state the starmetal ore will revert into when used up by a celestial crystal cluster. Obtain a valid state-string via '/astralsorcery serialize look' and look at the block you want to get. (Chat-Message can be copied)
+	starmetalRevertState = "minecraft:iron_ore"
 
 [lightnetwork]
 	#NOTE: ONLY run this once and set it to false again afterwards, nothing will be gained by setting this to true permanently, just longer loading times. When set to true and the server started, this will perform an integrity check over all nodes of the starlight network whenever a world gets loaded, removing invalid ones in the process. This might, depending on network sizes, take a while. It'll leave a message in the console when it's done. After this check has been run, you might need to tear down and rebuild your starlight network in case something doesn't work anymore.
@@ -445,9 +447,9 @@
 			#Range: > 10
 			maxFishTickTime = 500
 			#Defines the minimum default tick-time until a fish may be fished by the ritual. Gets reduced internally the more starlight was provided at the ritual.
-			#Range: > 20
-			
+			#Range: > 5
 			minFishTickTime = 100
+
 		[constellation.effect.pelotrio]
 			#Set this to false to disable this ritual effect
 			enabled = true
@@ -667,7 +669,7 @@
 
 	[registries.fluid_rarities]
 		#Defines fluid-rarities and amounts for the evershifting fountain's neromantic prime. The lower the relative rarity, the more rare the fluid. Format: <FluidName>;<guaranteedMbAmount>;<additionalRandomMbAmount>;<rarity>
-		fluid_rarities = ["minecraft:water;2147483647;2147483647;14000", "minecraft:lava;4000000;1000000;7500","pneumaticcraft:oil;2500000;1000000;5000","mekanismgenerators:flowing_fusion_fuel;1000000;500000;100","industrialforegoing:sewage_fluid;10000000;5000000;250","bloodmagic:life_essence_fluid_flowing;5000000;2500000;250","industrialforegoing:sludge_fluid;1000000;1000000;200","immersivepetroleum:napalm;500000;500000;100","industrialforegoing:essence_fluid;500000;100000;300", "mekanism:flowing_heavy_water;10000000;2000000;2500"]
+		fluid_rarities = ["minecraft:water;2147483647;2147483647;14000", "minecraft:lava;4000000;1000000;7500", "pneumaticcraft:oil;2500000;1000000;5000", "mekanismgenerators:flowing_fusion_fuel;1000000;500000;100", "industrialforegoing:sewage_fluid;10000000;5000000;250", "bloodmagic:life_essence_fluid_flowing;5000000;2500000;250", "industrialforegoing:sludge_fluid;1000000;1000000;200", "immersivepetroleum:napalm;500000;500000;100", "industrialforegoing:essence_fluid;500000;100000;300", "mekanism:flowing_heavy_water;10000000;2000000;2500"]
 
 	[registries.technical_entities]
 		#Defines entities whose purpose is mostly technical and less gameplay impactful. Those will be excluded from effects that manipulate entities. Add entities by their entity type name.Format: <EntityTypeName>
@@ -679,7 +681,7 @@
 
 	[registries.amulet_enchantments]
 		#Defines a whitelist of which enchantments can be rolled and buffed by the enchantment-amulet. The higher the weight, the more likely that roll is selected.Format: <enchantment-registry-name>;<weight>
-		amulet_enchantments = ["minecraft:protection;10", "minecraft:fire_protection;5", "minecraft:feather_falling;5", "minecraft:blast_protection;2", "minecraft:projectile_protection;5", "minecraft:respiration;2", "minecraft:aqua_affinity;2", "minecraft:thorns;1", "minecraft:depth_strider;2",   "minecraft:sharpness;10", "minecraft:smite;5", "minecraft:bane_of_arthropods;5", "minecraft:knockback;5", "minecraft:fire_aspect;2", "minecraft:looting;2", "minecraft:sweeping;2", "minecraft:efficiency;10", "minecraft:unbreaking;5", "minecraft:fortune;2", "minecraft:power;10", "minecraft:punch;2", "minecraft:flame;2", "minecraft:infinity;1", "minecraft:luck_of_the_sea;2", "minecraft:lure;2", "minecraft:loyalty;5", "minecraft:impaling;2", "minecraft:riptide;2", "minecraft:channeling;1", "minecraft:multishot;2", "minecraft:quick_charge;5", "minecraft:piercing;10", "minecraft:mending;2", "gunswithoutroses:impact;10", "gunswithoutroses:bullseye;10", "gunswithoutroses:sleight_of_hand;5", "gunswithoutroses:preserving;2", "naturesaura:aura_mending;2", "ensorcelled:enchantmentminer;1", "morevanillalib:repairing_luck;2", "astralsorcery:night_vision;1", "astralsorcery:scorching_heat;1", "farmersdelight:backstabbing;5", "ars_nouveau:mana_regen;5", "ars_nouveau:mana_boost;5", "ensorcellation:magic_protection;5", "ensorcellation:displacement;2", "ensorcellation:fire_rebuke;1", "ensorcellation:frost_rebuke;1", "ensorcellation:exp_boost;5", "ensorcellation:gourmand;5", "ensorcellation:reach;5", "ensorcellation:vitality;1", "ensorcellation:damage_ender;5", "ensorcellation:damage_illager;5", "ensorcellation:damage_villager;5", "ensorcellation:cavalier;5", "ensorcellation:frost_aspect;2", "ensorcellation:instigating;5", "ensorcellation:leech;5", "ensorcellation:magic_edge;2", "ensorcellation:vorpal;2", "ensorcellation:excavating;2", "ensorcellation:hunter;1", "ensorcellation:quick_draw;5", "ensorcellation:trueshot;5", "ensorcellation:volley;2", "ensorcellation:angler;1", "ensorcellation:pilfering;2", "ensorcellation:furrowing;5", "ensorcellation:tilling;2", "ensorcellation:weeding;5", "ensorcellation:bulwark;5", "ensorcellation:phalanx;5", "ensorcellation:soulbound;5", "travel_anchors:range;2", "apotheosis:hell_infusion;1", "apotheosis:depth_miner;2", "apotheosis:scavenger;1", "apotheosis:icy_thorns;2", "apotheosis:shield_bash;2", "apotheosis:reflective;2", "apotheosis:knowledge;2", "apotheosis:natures_blessing;2", "apotheosis:rebounding;2", "apotheosis:magic_protection;5", "apotheosis:sea_infusion;1", "apotheosis:bane_of_illagers;5", "apotheosis:obliteration;2", "apotheosis:crescendo;2", "apotheosis:capturing;1"]
+		amulet_enchantments = ["minecraft:protection;5", "minecraft:respiration;2", "minecraft:sharpness;5", "minecraft:looting;2", "minecraft:sweeping;2", "minecraft:fortune;2", "minecraft:power;5", "minecraft:impaling;2", "minecraft:multishot;2", "gunswithoutroses:impact;5", "ars_nouveau:mana_regen;5", "ars_nouveau:mana_boost;5", "ensorcellation:magic_protection;5", "ensorcellation:exp_boost;5", "ensorcellation:gourmand;5", "ensorcellation:vitality;1", "ensorcellation:magic_edge;2", "ensorcellation:vorpal;2", "apotheosis:knowledge;2", "apotheosis:crescendo;2", "apotheosis:capturing;1"]
 
 	[registries.gem_attributes]
 		#Format: '<attributeRegistryName>;<integerWeight>' Defines the attributes Perk Gems can roll.
@@ -687,14 +689,16 @@
 
 	[registries.perk_void_trash_ore]
 		#Format: '<tagName>;<integerWeight>' Defines random-weighted ore-selection data. Define item-tags to select from here with associated weight. Specific mods can be blacklisted in the general AstralSorcery config in 'modidOreBlacklist'.
-		perk_void_trash_ore = ["forge:ores/aluminum;1200","forge:ores/apatite;700","forge:ores/mana;200", "forge:ores/bitumen;1000","forge:ores/cinnabar;500","forge:ores/coal;5200","forge:ores/copper;2000","forge:ores/diamond;120","forge:ores/dimensional;20","forge:ores/emerald;100","forge:ores/fluorite;50","forge:ores/gold;550","forge:ores/iron;2500","forge:ores/lapis;360","forge:ores/lead;1500","forge:ores/nickel;100","forge:ores/osmium;1500","forge:ores/potassium_nitrate;250","forge:ores/redstone;700","forge:ores/silver;1000","forge:ores/sulfur;300","forge:ores/tin;1800","forge:ores/uranium;400","forge:ores/zinc;1000"]
+		perk_void_trash_ore = ["forge:ores/aluminum;1200", "forge:ores/apatite;700", "forge:ores/mana;200", "forge:ores/bitumen;1000", "forge:ores/cinnabar;500", "forge:ores/coal;5200", "forge:ores/copper;2000", "forge:ores/diamond;120", "forge:ores/dimensional;20", "forge:ores/emerald;100", "forge:ores/fluorite;50", "forge:ores/gold;550", "forge:ores/iron;2500", "forge:ores/lapis;360", "forge:ores/lead;1500", "forge:ores/nickel;100", "forge:ores/osmium;1500", "forge:ores/potassium_nitrate;250", "forge:ores/redstone;700", "forge:ores/silver;1000", "forge:ores/sulfur;300", "forge:ores/tin;1800", "forge:ores/uranium;400", "forge:ores/zinc;1000"]
+
 	[registries.perk_stone_enrichment_ore]
 		#Format: '<tagName>;<integerWeight>' Defines random-weighted ore-selection data. Define block-tags to select from here with associated weight. Specific mods can be blacklisted in the general AstralSorcery config in 'modidOreBlacklist'.
-		perk_stone_enrichment_ore = ["forge:ores/aluminum;1200","forge:ores/apatite;700","forge:ores/mana;200", "forge:ores/bitumen;1000","forge:ores/cinnabar;500","forge:ores/coal;5200","forge:ores/copper;2000","forge:ores/diamond;120","forge:ores/dimensional;20","forge:ores/emerald;100","forge:ores/fluorite;50","forge:ores/gold;550","forge:ores/iron;2500","forge:ores/lapis;360","forge:ores/lead;1500","forge:ores/nickel;100","forge:ores/osmium;1500","forge:ores/potassium_nitrate;250","forge:ores/redstone;700","forge:ores/silver;1000","forge:ores/sulfur;300","forge:ores/tin;1800","forge:ores/uranium;400","forge:ores/zinc;1000"]
+		perk_stone_enrichment_ore = ["forge:ores/aluminum;1200", "forge:ores/apatite;700", "forge:ores/mana;200", "forge:ores/bitumen;1000", "forge:ores/cinnabar;500", "forge:ores/coal;5200", "forge:ores/copper;2000", "forge:ores/diamond;120", "forge:ores/dimensional;20", "forge:ores/emerald;100", "forge:ores/fluorite;50", "forge:ores/gold;550", "forge:ores/iron;2500", "forge:ores/lapis;360", "forge:ores/lead;1500", "forge:ores/nickel;100", "forge:ores/osmium;1500", "forge:ores/potassium_nitrate;250", "forge:ores/redstone;700", "forge:ores/silver;1000", "forge:ores/sulfur;300", "forge:ores/tin;1800", "forge:ores/uranium;400", "forge:ores/zinc;1000"]
 
 	[registries.mineralis_ritual_ore]
 		#Format: '<tagName>;<integerWeight>' Defines random-weighted ore-selection data. Define block-tags to select from here with associated weight. Specific mods can be blacklisted in the general AstralSorcery config in 'modidOreBlacklist'.
-		mineralis_ritual_ore = ["forge:ores/aluminum;1200","forge:ores/apatite;700","forge:ores/mana;200", "forge:ores/bitumen;1000","forge:ores/cinnabar;500","forge:ores/coal;2400","forge:ores/copper;2000","forge:ores/diamond;120","forge:ores/dimensional;20","forge:ores/emerald;100","forge:ores/fluorite;50","forge:ores/gold;550","forge:ores/iron;2500","forge:ores/lapis;360","forge:ores/lead;1500","forge:ores/nickel;100","forge:ores/osmium;1500","forge:ores/potassium_nitrate;250","forge:ores/redstone;700","forge:ores/silver;1000","forge:ores/sulfur;300","forge:ores/tin;1800","forge:ores/uranium;400","forge:ores/zinc;1000"]
+		mineralis_ritual_ore = ["forge:ores/aluminum;1200", "forge:ores/apatite;700", "forge:ores/mana;200", "forge:ores/bitumen;1000", "forge:ores/cinnabar;500", "forge:ores/coal;2400", "forge:ores/copper;2000", "forge:ores/diamond;120", "forge:ores/dimensional;20", "forge:ores/emerald;100", "forge:ores/fluorite;50", "forge:ores/gold;550", "forge:ores/iron;2500", "forge:ores/lapis;360", "forge:ores/lead;1500", "forge:ores/nickel;100", "forge:ores/osmium;1500", "forge:ores/potassium_nitrate;250", "forge:ores/redstone;700", "forge:ores/silver;1000", "forge:ores/sulfur;300", "forge:ores/tin;1800", "forge:ores/uranium;400", "forge:ores/zinc;1000"]
+
 	[registries.entity_transmutation]
 		#Defines the entity types the corrupted pelotrio ritual can transmute from and to. Format: <EntityTypeFrom>;<EntityTypeTo>
 		entity_transmutation = ["minecraft:skeleton;minecraft:wither_skeleton", "minecraft:villager;minecraft:witch", "minecraft:pig;minecraft:zombified_piglin", "minecraft:cow;minecraft:zombie", "minecraft:parrot;minecraft:ghast", "minecraft:chicken;minecraft:blaze", "minecraft:sheep;minecraft:stray", "minecraft:horse;minecraft:skeleton_horse"]


### PR DESCRIPTION
So, warning... this doesn't work for me at all. :D but it might be a java issue on my end. Seems to work for Quezler though.

Anyway, the goal here is to remove a lot of the completely useless or less desireable enchants from the pool, making this late game item a bit more useful without requiring hours of re-rolling stats.

I've tried to focus it down to just those enchants that would be most useful to have, or would have the greatest impact. So instead of all the various protections, just general protection and magic protection are in the list. Similarly, many damage enchants are culled, leaving just sharpness and magic edge. 

Would like to see if anyone else is having issues with this, or if I'm just the odd duck out. 