### PR TITLE
[Expert] Alchemy Mastery Shard Update

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -91,6 +91,8 @@
     "item.kubejs.imaharas_indelible_electrodes": "Imahara's Indelible Electrodes",
     "item.kubejs.bright_constellation_box": "Bright Constellation Box",
     "item.kubejs.dim_constellation_box": "Dim Constellation Box",
+    "item.kubejs.diy_mixer": "DIY Industrial Mixer",
+    "item.kubejs.diy_bottling_machine": "DIY Bottling Machine",
 
     "item.kubejs.engineers_school_project": "Engineer's School Project",
     "item.kubejs.partial_engineers_school_project": "Partial Engineer's School Project",
@@ -116,6 +118,8 @@
     "item.kubejs.partial_mimirs_memory_box": "Partial Mimir's Memory Box™",
     "item.kubejs.box_of_thankful_dinners": "Box of Thankful Dinners",
     "item.kubejs.partial_box_of_thankful_dinners": "Partial Box of Thankful Dinners",
+    "item.kubejs.stim_pack": "Stimpack",
+    "item.kubejs.partial_stim_pack": "Partial Stimpack",
 
     "block.kubejs.firmament": "Firmament",
     "item.kubejs.partial_alloybrick": "Partial Kiln Brick",

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/atum/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/atum/shapeless.js
@@ -1,0 +1,38 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:expert/atum/shapeless/';
+
+    const recipes = [
+        {
+            output: '3x atum:linen_bandage',
+            inputs: [
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                Item.of('minecraft:potion', '{Potion:"minecraft:strong_healing"}')
+            ],
+            id: `${id_prefix}linen_bandage_medium`
+        },
+        {
+            output: '8x atum:linen_bandage',
+            inputs: [
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                Item.of('botania:brew_vial', '{brewKey:"botania:healing"}'),
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                'atum:linen_cloth',
+                'atum:linen_cloth'
+            ],
+            id: `${id_prefix}linen_bandage_heavy`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.shapeless(recipe.output, recipe.inputs).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -565,7 +565,7 @@ onEvent('recipes', (event) => {
             input: 'mekanism:cardboard_box',
             outputs: ['kubejs:stim_pack'],
             transitionalItem: 'kubejs:partial_stim_pack',
-            loops: 60,
+            loops: 25,
             sequence: [
                 {
                     type: 'deploying',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -560,6 +560,48 @@ onEvent('recipes', (event) => {
                 }
             ],
             id: `${id_prefix}box_of_thankful_dinners`
+        },
+        {
+            input: 'mekanism:cardboard_box',
+            outputs: ['kubejs:stim_pack'],
+            transitionalItem: 'kubejs:partial_stim_pack',
+            loops: 60,
+            sequence: [
+                {
+                    type: 'deploying',
+                    input: [
+                        'kubejs:partial_stim_pack',
+                        Item.of('botania:incense_stick', '{brewKey:"botania:emptiness"}')
+                    ],
+                    output: 'kubejs:partial_stim_pack'
+                },
+                {
+                    type: 'deploying',
+                    input: ['kubejs:partial_stim_pack', Item.of('botania:brew_flask', '{brewKey:"botania:regen"}')],
+                    output: 'kubejs:partial_stim_pack'
+                },
+                {
+                    type: 'deploying',
+                    input: ['kubejs:partial_stim_pack', Item.of('botania:brew_flask', '{brewKey:"botania:speed"}')],
+                    output: 'kubejs:partial_stim_pack'
+                },
+                {
+                    type: 'deploying',
+                    input: ['kubejs:partial_stim_pack', 'atum:linen_bandage'],
+                    output: 'kubejs:partial_stim_pack'
+                },
+                {
+                    type: 'deploying',
+                    input: ['kubejs:partial_stim_pack', 'atum:linen_bandage'],
+                    output: 'kubejs:partial_stim_pack'
+                },
+                {
+                    type: 'deploying',
+                    input: ['kubejs:partial_stim_pack', 'atum:linen_bandage'],
+                    output: 'kubejs:partial_stim_pack'
+                }
+            ],
+            id: `${id_prefix}stim_pack`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -577,14 +577,16 @@ onEvent('recipes', (event) => {
                 },
                 {
                     type: 'deploying',
-                    input: ['kubejs:partial_stim_pack', Item.of('botania:brew_flask', '{brewKey:"botania:regen"}')],
+                    input: [
+                        'kubejs:partial_stim_pack',
+                        Item.of(
+                            'ars_nouveau:potion_flask',
+                            '{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:"minecraft:milk_bucket",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:1b,Amplifier:0b}],Potion:"minecraft:strong_healing"}'
+                        )
+                    ],
                     output: 'kubejs:partial_stim_pack'
                 },
-                {
-                    type: 'deploying',
-                    input: ['kubejs:partial_stim_pack', Item.of('botania:brew_flask', '{brewKey:"botania:speed"}')],
-                    output: 'kubejs:partial_stim_pack'
-                },
+
                 {
                     type: 'deploying',
                     input: ['kubejs:partial_stim_pack', 'atum:linen_bandage'],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -565,7 +565,7 @@ onEvent('recipes', (event) => {
             input: 'mekanism:cardboard_box',
             outputs: ['kubejs:stim_pack'],
             transitionalItem: 'kubejs:partial_stim_pack',
-            loops: 25,
+            loops: 30,
             sequence: [
                 {
                     type: 'deploying',
@@ -586,7 +586,17 @@ onEvent('recipes', (event) => {
                     ],
                     output: 'kubejs:partial_stim_pack'
                 },
-
+                {
+                    type: 'deploying',
+                    input: [
+                        'kubejs:partial_stim_pack',
+                        Item.of(
+                            'ars_nouveau:potion_flask',
+                            '{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:"minecraft:milk_bucket",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:3600,Id:22b,Amplifier:1b}],Potion:"apotheosis:strong_resistance"}'
+                        )
+                    ],
+                    output: 'kubejs:partial_stim_pack'
+                },
                 {
                     type: 'deploying',
                     input: ['kubejs:partial_stim_pack', 'atum:linen_bandage'],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -581,7 +581,7 @@ onEvent('recipes', (event) => {
                         'kubejs:partial_stim_pack',
                         Item.of(
                             'ars_nouveau:potion_flask',
-                            '{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:"minecraft:milk_bucket",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:1b,Amplifier:0b}],Potion:"minecraft:strong_healing"}'
+                            '{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:"minecraft:milk_bucket",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:1b,Amplifier:0b}],Potion:"minecraft:strong_regeneration"}'
                         )
                     ],
                     output: 'kubejs:partial_stim_pack'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/enigmatic_tree_of_life.js
@@ -46,16 +46,12 @@ onEvent('recipes', (event) => {
         {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'kubejs:alchemy_mastery_shard', count: 1 } }],
             inputs: [
-                { type: 'masterfulmachinery:items', data: { item: 'naturesaura:death_ring', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { item: 'occultism:soul_gem', count: 2 } },
-                { type: 'masterfulmachinery:items', data: { item: 'bloodmagic:looting_anointment_l', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { item: 'ars_nouveau:wixie_charm', count: 3 } },
-                { type: 'masterfulmachinery:items', data: { item: 'naturesaura:pet_reviver', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { item: 'astralsorcery:nocturnal_powder', count: 16 } },
-                { type: 'masterfulmachinery:items', data: { item: 'minecraft:enchanted_golden_apple', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { item: 'atum:linen_bandage', count: 33 } },
-                { type: 'masterfulmachinery:items', data: { item: 'darkutils:rune_weakness', count: 9 } },
-                { type: 'masterfulmachinery:items', data: { item: 'darkutils:anchor_plate', count: 9 } },
+                { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_mixer', count: 1 } },
+                { type: 'masterfulmachinery:items', data: { item: 'kubejs:diy_bottling_machine', count: 1 } },
+                { type: 'masterfulmachinery:items', data: { item: 'kubejs:stim_pack', count: 1 } },
+                { type: 'masterfulmachinery:items', data: { item: 'naturesaura:death_ring', count: 5 } },
+                { type: 'masterfulmachinery:items', data: { item: 'naturesaura:pet_reviver', count: 5 } },
+
                 { type: 'masterfulmachinery:botania_mana', consumeInstantly: true, data: { amount: 500 * 60 } }
             ],
             ticks: 60,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -588,6 +588,34 @@ onEvent('recipes', (event) => {
             pressure: 4.5,
             results: [{ item: 'kubejs:diy_furnace_engine_kit', count: 1 }],
             id: `${id_prefix}diy_furnace_engine_kit`
+        },
+        {
+            inputs: [
+                { item: 'immersiveengineering:fluid_pipe', count: 3 },
+                { item: 'immersiveengineering:light_engineering', count: 4 },
+                { item: 'immersiveengineering:rs_engineering', count: 1 },
+                { item: 'immersiveengineering:sheetmetal_iron', count: 4 },
+                { item: 'immersiveengineering:steel_fence', count: 1 },
+                { item: 'immersiveengineering:steel_scaffolding_standard', count: 5 },
+                { item: 'mekanism:cardboard_box', count: 1 }
+            ],
+            pressure: 4.5,
+            results: [{ item: 'kubejs:diy_mixer', count: 1 }],
+            id: `${id_prefix}diy_mixer`
+        },
+        {
+            inputs: [
+                { item: 'immersiveengineering:conveyor_basic', count: 3 },
+                { item: 'immersiveengineering:fluid_pump', count: 2 },
+                { item: 'immersiveengineering:light_engineering', count: 2 },
+                { item: 'immersiveengineering:rs_engineering', count: 1 },
+                { item: 'immersiveengineering:sheetmetal_steel', count: 2 },
+                { item: 'immersiveengineering:steel_scaffolding_standard', count: 3 },
+                { item: 'mekanism:cardboard_box', count: 1 }
+            ],
+            pressure: 4.5,
+            results: [{ item: 'kubejs:diy_bottling_machine', count: 1 }],
+            id: `${id_prefix}diy_bottling_machine`
         }
     ];
 

--- a/kubejs/startup_scripts/item_registry.js
+++ b/kubejs/startup_scripts/item_registry.js
@@ -184,7 +184,8 @@ onEvent('item.registry', (event) => {
         { name: 'altar_of_birthing_kit', texture: 'packing_crate_blue' },
         { name: 'diy_furnace_engine_kit', texture: 'packing_crate_blue' },
         { name: 'imaharas_indelible_electrodes', texture: 'advanced_packing_crate_green' },
-
+        { name: 'diy_mixer', texture: 'advanced_packing_crate_green' },
+        { name: 'diy_bottling_machine', texture: 'advanced_packing_crate_purple' },
         { name: 'bright_constellation_box', texture: 'advanced_packing_crate_purple' },
         { name: 'dim_constellation_box', texture: 'advanced_packing_crate_green' },
 
@@ -206,6 +207,8 @@ onEvent('item.registry', (event) => {
         { name: 'partial_mimirs_memory_box', texture: 'packing_crate_lime' },
         { name: 'box_of_thankful_dinners', texture: 'advanced_packing_crate_purple' },
         { name: 'partial_box_of_thankful_dinners', texture: 'advanced_packing_crate_purple' },
+        { name: 'stim_pack', texture: 'packing_crate_red' },
+        { name: 'partial_stim_pack', texture: 'packing_crate_red' },
 
         { name: 'engineers_school_upgrades', texture: 'advanced_packing_crate_gray' },
         { name: 'partial_engineers_school_upgrades', texture: 'advanced_packing_crate_gray' },


### PR DESCRIPTION
First, the shard itself is streamlined to more on theme items: 
![image](https://user-images.githubusercontent.com/9543430/177450954-5f5b3c3d-9776-49be-bda8-14d2daaa3de3.png)

This is an IE brewing setup, a Stimpack full of healing supplies, craftable totems of undying (ring of undying), and the pet token to keep them from dying. 

All very on point with the message of the quest: 
![image](https://user-images.githubusercontent.com/9543430/177451118-d1db7d0a-ef55-4436-8128-274444953589.png)

Mixer Kit:
![image](https://user-images.githubusercontent.com/9543430/177451157-9d0566fd-6470-4921-8565-417fd7bf56e6.png)

Bottling Machine
![image](https://user-images.githubusercontent.com/9543430/177451175-9e990fa0-df0d-4224-89e6-b62fc55ee34f.png)

The Stimpack. This is the real meat of the craft, I think.
![image](https://user-images.githubusercontent.com/9543430/177565395-748dfd45-73af-42f3-a525-b71e4bc0a89e.png)

It's a fairly sizeable increase in the number of potions, but mainly introduces two flasks and an incense stick. Automation of the botanical brewery for the incense stick would have been done long before, but the potion flasks may require some new automation to set up the Ars Nouveau Potion Melder.

Also introduces a few options for making those bandages with varying levels of efficiency:
![image](https://user-images.githubusercontent.com/9543430/177453041-9fee9b42-6f80-4e87-a3ca-254bc91ef544.png)

