### PR TITLE
[Expert] Fix Colored Botany Pot recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1407,7 +1407,16 @@ onEvent('recipes', (event) => {
                 id: `botanypots:crafting/${color}_botany_pot`
             },
             {
-                inputs: [`botanypots:${color}_botany_pot`, 'ars_nouveau:sylph_charm', 'naturesaura:grated_chute'],
+                inputs: [
+                    'ars_nouveau:sylph_charm',
+                    `botanypots:${color}_botany_pot`,
+                    'astralsorcery:tree_beacon',
+                    'botania:enchanted_soil',
+                    'botania:enchanted_soil',
+                    '#botania:runes/midgard',
+                    'naturesaura:grated_chute',
+                    '#botania:runes/midgard'
+                ],
                 inputFluid: 'materialis:molten_fairy',
                 inputFluidAmount: 1296,
                 processingTime: 600,


### PR DESCRIPTION
Colored hopping pots were considerably cheaper due to an oversight. Fixed.