### PR TITLE
Remove Mushroom Colonies from recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cooking_pot.js
@@ -1,0 +1,39 @@
+onEvent('recipes', (event) => {
+    const id_prefix = 'enigmatica:base/farmersdelight/cooking/';
+    const recipes = [
+        {
+            inputs: [
+                '#forge:crops/rice',
+                '#forge:vegetables',
+                'farmersdelight:tomato_sauce',
+                'minecraft:baked_potato',
+                'minecraft:brown_mushroom',
+                'minecraft:sweet_berries'
+            ],
+            output: 'farmersdelight:stuffed_pumpkin_block',
+            container: 'minecraft:pumpkin',
+            count: 1,
+            cookingTime: 400,
+            id: `farmersdelight:cooking/stuffed_pumpkin_block`
+        },
+        {
+            inputs: ['#forge:raw_fishes/perch', 'minecraft:red_mushroom', '#forge:crops/rice', '#forge:crops/tomato'],
+            output: 'abnormals_delight:perch_with_mushrooms',
+            container: 'minecraft:bowl',
+            count: 1,
+            cookingTime: 200,
+            id: `abnormals_delight:perch_with_mushrooms`
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.type = 'farmersdelight:cooking';
+        recipe.ingredients = recipe.inputs.map((input) => Ingredient.of(input).toJson());
+        recipe.result = { item: recipe.output, count: recipe.count };
+        if (recipe.container) {
+            recipe.container = { item: recipe.container };
+        }
+
+        event.custom(recipe).id(recipe.id);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
@@ -29,7 +29,7 @@ onEvent('recipes', (event) => {
             inputs: ['eidolon:enchanted_ash', '#forge:dusts/ender'],
             output: 'eidolon:ender_calx',
             count: 2,
-            cookingTime: 200,
+            cookingTime: 50,
             id: `${id_prefix}ender_calx`
         },
         {
@@ -71,17 +71,18 @@ onEvent('recipes', (event) => {
             inputs: ['eidolon:enchanted_ash', '#forge:dusts/charcoal', '#forge:dusts/sulfur'],
             output: 'minecraft:gunpowder',
             count: 4,
-            cookingTime: 200,
+            cookingTime: 50,
             id: `${id_prefix}gunpowder`
         }
     ];
 
     colors.forEach((color) => {
         recipes.push({
-            inputs: [`#forge:dyes/${color}`, '#enigmatica:candle_materials', '#forge:string'],
+            inputs: [`#forge:dyes/${color}`, '#enigmatica:candle_materials'],
             output: `quark:${color}_candle`,
+            container: 'minecraft:string',
             count: 1,
-            cookingTime: 100,
+            cookingTime: 50,
             id: `quark:building/crafting/candles/${color}_candle`
         });
     });
@@ -90,6 +91,9 @@ onEvent('recipes', (event) => {
         recipe.type = 'farmersdelight:cooking';
         recipe.ingredients = recipe.inputs.map((input) => Ingredient.of(input).toJson());
         recipe.result = { item: recipe.output, count: recipe.count };
+        if (recipe.container) {
+            recipe.container = { item: recipe.container };
+        }
 
         event.custom(recipe).id(recipe.id);
     });


### PR DESCRIPTION
These are not fun to automate by any means and would require the player to do some really off the wall things to make in the quantities needed for the Mastery Shards.

Also reduces the time it takes to craft a few other cooking pot recipes. Notably Ender Calx and Candles. Candles now need string as the secondary item rather than in the pot itself.