### PR TITLE
[Expert] Speed increases

### DIFF
--- a/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/expert/serverconfig/immersiveengineering-server.toml
@@ -155,6 +155,14 @@
 	#Range: 0.001 ~ 1000.0
 	timeModifier = 0.1
 
+[machines.mixer]
+	#A modifier to apply to the energy costs of every mixer recipe
+	#Range: 0.001 ~ 1000.0
+	energyModifier = 8.0
+	#A modifier to apply to the time of every mixer recipe
+	#Range: 0.001 ~ 1000.0
+	timeModifier = 0.005
+
 [machines.sawmill]
 	#A modifier to apply to the energy costs of every sawmill recipe
 	#Range: 0.001 ~ 1000.0

--- a/config/configswapper/normal/serverconfig/immersiveengineering-server.toml
+++ b/config/configswapper/normal/serverconfig/immersiveengineering-server.toml
@@ -152,6 +152,14 @@
 	#Range: 0.001 ~ 1000.0
 	timeModifier = 1.0
 
+[machines.mixer]
+	#A modifier to apply to the energy costs of every mixer recipe
+	#Range: 0.001 ~ 1000.0
+	energyModifier = 1.0
+	#A modifier to apply to the time of every mixer recipe
+	#Range: 0.001 ~ 1000.0
+	timeModifier = 1.0
+
 [machines.sawmill]
 	#A modifier to apply to the energy costs of every sawmill recipe
 	#Range: 0.001 ~ 1000.0

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/advanced_assembly_table.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/advanced_assembly_table.js
@@ -12,7 +12,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:basic_circuit_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_basic_circuit_package`
         },
         {
@@ -23,7 +23,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:basic_memory_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_basic_memory_package`
         },
         {
@@ -34,7 +34,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_500_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_cpu_core_500_package`
         },
         {
@@ -45,7 +45,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_1000_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_cpu_core_1000_package`
         },
         {
@@ -56,7 +56,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_2000_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_cpu_core_2000_package`
         },
         {
@@ -65,7 +65,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'pneumaticcraft:empty_pcb', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 240,
+            ticks: 120,
             id: `${id_prefix}batch_unassembled_pcb`
         }
     ];
@@ -111,7 +111,7 @@ onEvent('recipes', (event) => {
                     },
                     { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
                 ],
-                ticks: 240,
+                ticks: 120,
                 id: `${id_prefix}batch_${partSize}_storage_part_assembly`
             });
         });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/advanced_assembly_table.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/advanced_assembly_table.js
@@ -12,7 +12,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:basic_circuit_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_basic_circuit_package`
         },
         {
@@ -23,7 +23,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:basic_memory_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_basic_memory_package`
         },
         {
@@ -34,7 +34,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_500_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_cpu_core_500_package`
         },
         {
@@ -45,7 +45,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_1000_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_cpu_core_1000_package`
         },
         {
@@ -56,7 +56,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'kubejs:cpu_core_2000_package', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_cpu_core_2000_package`
         },
         {
@@ -65,7 +65,7 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'pneumaticcraft:empty_pcb', count: 32 } },
                 { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
             ],
-            ticks: 120,
+            ticks: 240,
             id: `${id_prefix}batch_unassembled_pcb`
         }
     ];
@@ -111,7 +111,7 @@ onEvent('recipes', (event) => {
                     },
                     { type: 'masterfulmachinery:pncr_pressure', perTick: true, data: { air: 300 * 4 } }
                 ],
-                ticks: 120,
+                ticks: 240,
                 id: `${id_prefix}batch_${partSize}_storage_part_assembly`
             });
         });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -282,8 +282,8 @@ onEvent('recipes', (event) => {
                 output: Ingredient.of(levigated_material).toJson(),
                 catalyst: Ingredient.of('naturesaura:crushing_catalyst').toJson(),
                 aura_type: 'naturesaura:overworld',
-                aura: 1500,
-                time: 10
+                aura: 300,
+                time: 1
             })
             .id(`enigmatica:expert/magical_ore_processing/aura/${material}`);
 


### PR DESCRIPTION
Dramatically increases the speed for the natural altar's ore processing step. Also increases aura cost per tick. 

Make the IE Mixer actually worth using. Makes it aproximately 8x faster than a maxed out (256 rotation) Create Mixer