### PR TITLE
Remove "This item is disabled" descriptions for docks from Dank Storage and Tank Null

### DIFF
--- a/kubejs/client_scripts/expert/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/expert/item_modifiers/jei_descriptions.js
@@ -61,8 +61,6 @@ onEvent('jei.information', (event) => {
         /powah:energy_cable_/,
         'eidolon:crucible',
         'eidolon:wooden_brewing_stand',
-        'tanknull:dock',
-        'dankstorage:dock',
         'engineersdecor:factory_placer'
     ];
     disabledItems.forEach((item) => {


### PR DESCRIPTION
Title.

Since these items have recently been re-enabled, the jei description doesn't make sense.