### PR TITLE
[Expert] Expand Wicked Altar uses

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
@@ -61,9 +61,16 @@ onEvent('recipes', (event) => {
             id: `${id_prefix}golden_carrot`
         },
         {
-            inputs: ['eidolon:enchanted_ash', '#forge:dusts/gold', '#forge:dusts/gold', 'minecraft:apple'],
+            inputs: [
+                'eidolon:enchanted_ash',
+                '#forge:dusts/gold',
+                'minecraft:apple',
+                'minecraft:apple',
+                'minecraft:apple',
+                'minecraft:apple'
+            ],
             output: 'minecraft:golden_apple',
-            count: 1,
+            count: 4,
             cookingTime: 200,
             id: `${id_prefix}golden_apple`
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/wicked_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/wicked_altar.js
@@ -303,8 +303,8 @@ onEvent('recipes', (event) => {
         {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'minecraft:golden_apple', count: 4 } }],
             inputs: [
-                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:apple', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                { type: 'masterfulmachinery:items', data: { item: 'minecraft:apple', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 1 } },
                 {
                     type: 'masterfulmachinery:fluids',
                     data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }
@@ -316,8 +316,8 @@ onEvent('recipes', (event) => {
         {
             outputs: [{ type: 'masterfulmachinery:items', data: { item: 'minecraft:golden_carrot', count: 4 } }],
             inputs: [
-                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:carrot', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                { type: 'masterfulmachinery:items', data: { item: 'minecraft:carrot', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 1 } },
                 {
                     type: 'masterfulmachinery:fluids',
                     data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }
@@ -331,8 +331,8 @@ onEvent('recipes', (event) => {
                 { type: 'masterfulmachinery:items', data: { item: 'minecraft:glistering_melon_slice', count: 4 } }
             ],
             inputs: [
-                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:melon_slice', count: 4 } },
-                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                { type: 'masterfulmachinery:items', data: { item: 'minecraft:melon_slice', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 1 } },
                 {
                     type: 'masterfulmachinery:fluids',
                     data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/wicked_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/masterful_machinery/wicked_altar.js
@@ -287,6 +287,59 @@ onEvent('recipes', (event) => {
             ],
             ticks: 50,
             id: `${id_prefix}outputroutingnode`
+        },
+        {
+            outputs: [{ type: 'masterfulmachinery:items', data: { item: 'eidolon:ender_calx', count: 8 } }],
+            inputs: [
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/ender_pearl', count: 8 } },
+                {
+                    type: 'masterfulmachinery:fluids',
+                    data: { fluid: 'bloodmagic:life_essence_fluid', amount: 80 }
+                }
+            ],
+            ticks: 10,
+            id: `${id_prefix}ender_calx`
+        },
+        {
+            outputs: [{ type: 'masterfulmachinery:items', data: { item: 'minecraft:golden_apple', count: 4 } }],
+            inputs: [
+                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:apple', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                {
+                    type: 'masterfulmachinery:fluids',
+                    data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }
+                }
+            ],
+            ticks: 10,
+            id: `${id_prefix}golden_apple`
+        },
+        {
+            outputs: [{ type: 'masterfulmachinery:items', data: { item: 'minecraft:golden_carrot', count: 4 } }],
+            inputs: [
+                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:carrot', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                {
+                    type: 'masterfulmachinery:fluids',
+                    data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }
+                }
+            ],
+            ticks: 10,
+            id: `${id_prefix}golden_carrot`
+        },
+        {
+            outputs: [
+                { type: 'masterfulmachinery:items', data: { item: 'minecraft:glistering_melon_slice', count: 4 } }
+            ],
+            inputs: [
+                { type: 'masterfulmachinery:items', data: { tag: 'minecraft:melon_slice', count: 4 } },
+                { type: 'masterfulmachinery:items', data: { tag: 'forge:dusts/gold', count: 2 } },
+                {
+                    type: 'masterfulmachinery:fluids',
+                    data: { fluid: 'bloodmagic:life_essence_fluid', amount: 150 }
+                }
+            ],
+            ticks: 10,
+            id: `${id_prefix}glistering_melon_slice`
         }
     ];
 


### PR DESCRIPTION
First, normalize the 'golden food' recipes in the cooking pot. Gold is cheap anyway.

![image](https://user-images.githubusercontent.com/9543430/183466072-68152c1c-dd79-49e9-8414-5e1ccdbfc640.png)
![image](https://user-images.githubusercontent.com/9543430/183466099-5888656f-fb7f-4cff-bb39-7157e20b3a48.png)

This should make these a little less painful to automate early on.

For later, new recipes are added to the Wicked Altar
Calx of the End
![image](https://user-images.githubusercontent.com/9543430/183467714-3153ac88-05eb-4fe8-9035-44b0aeb0f0a5.png)

Golden Carrots
![image](https://user-images.githubusercontent.com/9543430/183468136-8b0fd3fd-a015-48a9-9d0a-afee94b2f74a.png)

Glistering Melon
![image](https://user-images.githubusercontent.com/9543430/183468163-c03c0757-afba-483e-b84c-7837e6381edc.png)

Golden Apples
![image](https://user-images.githubusercontent.com/9543430/183468196-2465839d-94ee-4634-8ac9-6dc24444c3cc.png)

All need a 'decent'ish amount of LP, but craft very quickly (10 ticks, compared to the 200 ticks in the cooking pot). The LP cost should be a non-issue for anyone with automated LP, however. 

