### PR TITLE
Blacklist anvils from PNC and IF enchant extraction

### DIFF
--- a/config/pneumaticcraft-common.toml
+++ b/config/pneumaticcraft-common.toml
@@ -98,7 +98,7 @@
 	#Fluid tag names that the Seismic Sensor will search for. Known vanilla tags are 'minecraft:water' and 'minecraft:lava'. Other available fluid tags are mod-dependent. By default, 'forge:crude_oil' is matched, allowing PneumaticCraft (and potentially other mods) crude oil.
 	seismic_sensor_fluid_tags = ["forge:crude_oil"]
 	#Blacklist items from being allowed in the Pressure Chamber disenchanting system. This is a starts-with string match, so you can match by mod, or individual item names as you need. Blacklisted by default are Quark Ancient Tomes, and all Tetra items; both can lead to enchantment duping as they have special enchantment mechanics.
-	disenchanting_blacklist = ["quark:ancient_tome", "tetra:"]
+	disenchanting_blacklist = ["quark:ancient_tome", "tetra:", "minecraft:anvil"]
 	#Are players in Creative mode exempt from Security Station block protection? If false, only server ops are exempt (command permission >= 2)
 	security_station_creative_players_exempt = false
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/industrialforegoing/enchantment_extractor_blacklist.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/industrialforegoing/enchantment_extractor_blacklist.js
@@ -1,10 +1,5 @@
 onEvent('item.tags', (event) => {
-    event
-        .get('industrialforegoing:enchantment_extractor_blacklist')
-        .add('tetra:modular_double')
-        .add('tetra:modular_shield')
-        .add('tetra:modular_single')
-        .add('tetra:modular_sword')
-        .add('tetra:modular_crossbow')
-        .add('tetra:modular_bow');
+    const items = ['minecraft:anvil', /tetra:modular_.*/];
+
+    event.get('industrialforegoing:enchantment_extractor_blacklist').add(items);
 });


### PR DESCRIPTION
Partially resolves #5167. Leaves tome of scrapping as I don't see a way to blacklist items from that...