### PR TITLE
[Expert] Runed Flavolite Fix

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -692,6 +692,24 @@ onEvent('recipes', (event) => {
             output: 'quark:rainbow_rune',
             count: 8,
             id: 'quark:tools/crafting/runes/rainbow_rune2'
+        },
+        {
+            inputs: [
+                'betterendforge:flavolite_polished',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora',
+                '#botania:runes/mana',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora',
+                '#forge:shards/aurora'
+            ],
+            mana: 4000 * 8,
+            output: 'betterendforge:flavolite_runed',
+            count: 2,
+            id: 'betterendforge:runed_flavolite'
         }
     ];
 


### PR DESCRIPTION
Moves recipe to the Runic Altar since the pedestal crafting it normally uses tends to break and is generally just not fun to automate.

Resolves #5187

![image](https://user-images.githubusercontent.com/9543430/187093411-1d297e4c-cb7d-4bc7-a9c4-56aa3dccb303.png)
