### PR TITLE
Scorching Heat modifications

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/enigmatica/crushing.js
@@ -74,7 +74,7 @@ onEvent('recipes', (event) => {
                 ingredient: recipe.input,
                 result: recipe.output
             })
-            .id(`${id_prefix}/pedestal_crushing/${recipe.id_suffix}`);
+            .id(`${id_prefix}pedestal_crushing/${recipe.id_suffix}`);
 
         // occultism
         event
@@ -85,7 +85,7 @@ onEvent('recipes', (event) => {
                 crushing_time: recipe.duration,
                 ignore_crushing_multiplier: recipe.ignore_occultism_multiplier
             })
-            .id(`${id_prefix}/occultism_crushing/${recipe.id_suffix}`);
+            .id(`${id_prefix}occultism_crushing/${recipe.id_suffix}`);
 
         // astralsorcery
         event
@@ -100,7 +100,7 @@ onEvent('recipes', (event) => {
                 acceptChaliceInput: true,
                 copyNBTToOutputs: false
             })
-            .id(`${id_prefix}/astralsorcery_infuser/${recipe.id_suffix}`);
+            .id(`${id_prefix}astralsorcery_infuser/${recipe.id_suffix}`);
 
         // industrialforegoing
         event
@@ -109,13 +109,13 @@ onEvent('recipes', (event) => {
                 input: recipe.input,
                 output: recipe.output
             })
-            .id(`${id_prefix}/industrialforegoing_crusher/${recipe.id_suffix}`);
+            .id(`${id_prefix}industrialforegoing_crusher/${recipe.id_suffix}`);
 
         // thermal
         event.recipes.thermal
             .pulverizer([recipe.output, recipe.secondary_output], recipe.input)
             .experience(recipe.experience)
-            .id(`${id_prefix}/thermal_pulverizer/${recipe.id_suffix}`);
+            .id(`${id_prefix}thermal_pulverizer/${recipe.id_suffix}`);
 
         // mekanism
         event.recipes.mekanism.enriching(recipe.output, recipe.input).id(`${id_prefix}/pedestals/${recipe.id_suffix}`);
@@ -123,12 +123,12 @@ onEvent('recipes', (event) => {
         // immersiveengineering
         event.recipes.immersiveengineering
             .crusher(recipe.output, recipe.input, recipe.secondary_output)
-            .id(`${id_prefix}/immersiveengineering_crusher/${recipe.id_suffix}`);
+            .id(`${id_prefix}immersiveengineering_crusher/${recipe.id_suffix}`);
 
         // create
         event.recipes.create
             .milling([recipe.output, recipe.secondary_output], recipe.input)
-            .id(`${id_prefix}/create_milling/${recipe.id_suffix}`);
+            .id(`${id_prefix}create_milling/${recipe.id_suffix}`);
 
         // ars_nouveau
         event
@@ -137,7 +137,7 @@ onEvent('recipes', (event) => {
                 input: Ingredient.of(recipe.input).toJson(),
                 output: [recipe.output.withChance(1.0), recipe.secondary_output]
             })
-            .id(`${id_prefix}/ars_nouveau_crushing/${recipe.id_suffix}`);
+            .id(`${id_prefix}ars_nouveau_crushing/${recipe.id_suffix}`);
     };
 
     recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
@@ -180,8 +180,15 @@ onEvent('recipes', (event) => {
             output: 'minecraft:gold_ingot',
             xp: 0.7,
             id: `${id_prefix}atum_relic_ore`
+        },
+        {
+            input: '#pneumaticcraft:plastic_bricks',
+            output: 'pneumaticcraft:plastic',
+            xp: 0.7,
+            id: 'pneumaticcraft:plastic_sheet_from_brick'
         }
     ];
+
     recipes.forEach((recipe) => {
         const re = event.blasting(recipe.output, recipe.input).id(recipe.id);
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -844,10 +844,11 @@ onEvent('recipes', (event) => {
         }
 
         var output = ingot,
-            input = `#forge:ores/${material}`;
+            input = `#forge:chunks/${material}`;
+        event.smelting(output, input).xp(0.7).id(`${id_prefix}smelting/${material}/ingot/from_chunk`);
 
-        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        input = `#forge:ores/${material}`;
+        event.blasting(output, input).xp(0.7).id(`${id_prefix}blasting/${material}/ingot/from_ore`);
     }
 
     function minecraft_gem_ore_smelting(event, material, ore, gem) {
@@ -866,8 +867,8 @@ onEvent('recipes', (event) => {
         var output = gem,
             input = `#forge:ores/${material}`;
 
-        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        event.smelting(output, input).xp(0.7).xp(0.7).id(`${id_prefix}smelting/${material}/gem/from_ore`);
+        event.blasting(output, input).xp(0.7).xp(0.7).id(`${id_prefix}blasting/${material}/gem/from_ore`);
     }
 
     function minecraft_dust_smelting(event, material, dust, ingot) {
@@ -886,8 +887,8 @@ onEvent('recipes', (event) => {
         var output = ingot,
             input = `#forge:dusts/${material}`;
 
-        fallback_id(event.smelting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
-        fallback_id(event.blasting(output, input).xp(0.7), `${id_prefix}${arguments.callee.name}/`);
+        event.smelting(output, input).xp(0.7).id(`${id_prefix}smelting/${material}/ingot/from_dust`);
+        event.blasting(output, input).xp(0.7).id(`${id_prefix}blasting/${material}/ingot/from_dust`);
     }
 
     function occultism_gem_ore_crushing(event, material, ore, dust, gem, shard) {
@@ -918,16 +919,15 @@ onEvent('recipes', (event) => {
                 return;
         }
 
-        fallback_id(
-            event.custom({
+        event
+            .custom({
                 type: 'occultism:crushing',
                 ingredient: { tag: input },
                 result: { item: output, count: count },
                 crushing_time: 100,
                 ignore_crushing_multiplier: false
-            }),
-            `${id_prefix}${arguments.callee.name}/`
-        );
+            })
+            .id(`${id_prefix}occultism_crushing/${material}/${materialProperties.output}/from_ore`);
     }
 
     function occultism_metal_ore_crushing(event, material, ore, dust, ingot) {


### PR DESCRIPTION
Makes metal ores un-smeltable by Scorching heat. The block form may be smelted in a Blast Furnace still, but not a regular furnace.

Similarly moves PNC plastic from Plastic Bricks to the Blast Furnace to prevent a dupe loop.