### PR TITLE
Fix A typo in Melter Task in Tcon quest line!

### DIFF
--- a/config/ftbquests/quests/chapters/tinkers_construct.snbt
+++ b/config/ftbquests/quests/chapters/tinkers_construct.snbt
@@ -508,7 +508,7 @@
 				{
 					id: "66575D6B48FFD434"
 					type: "item"
-					title: "Seared Melter"
+					title: "Seared Heater"
 					item: "tconstruct:seared_heater"
 				}
 				{


### PR DESCRIPTION
Pretty much fast fix for a typo in Melter Quest, where `Seared Heater` was named `Seared Melter` 😅
![obraz](https://user-images.githubusercontent.com/60540476/218276255-8aa46d8d-bf49-4294-bf80-c138183dbbf6.png)
![obraz](https://user-images.githubusercontent.com/60540476/218276270-040f5512-6676-4403-9caf-33e7cba2aabe.png)
