### PR TITLE
[Expert] More complete fix for scorching heat

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -66,7 +66,6 @@ onEvent('recipes', (event) => {
             ingot
         );
 
-        minecraft_ore_ingot_smelting(event, material, ore, ingot);
         minecraft_gem_ore_smelting(event, material, ore, gem);
         minecraft_dust_smelting(event, material, dust, ingot);
 
@@ -828,27 +827,6 @@ onEvent('recipes', (event) => {
         event.recipes.mekanism
             .enriching(Item.of(dust, 2), `#forge:ores/${material}`)
             .id(`mekanism:processing/${material}/dust/from_ore`);
-    }
-
-    function minecraft_ore_ingot_smelting(event, material, ore, ingot) {
-        if (ore == air || ingot == air) {
-            return;
-        }
-
-        blacklistedMaterials = ['ender'];
-
-        for (var i = 0; i < blacklistedMaterials.length; i++) {
-            if (blacklistedMaterials[i] == material) {
-                return;
-            }
-        }
-
-        var output = ingot,
-            input = `#forge:chunks/${material}`;
-        event.smelting(output, input).xp(0.7).id(`${id_prefix}smelting/${material}/ingot/from_chunk`);
-
-        input = `#forge:ores/${material}`;
-        event.blasting(output, input).xp(0.7).id(`${id_prefix}blasting/${material}/ingot/from_ore`);
     }
 
     function minecraft_gem_ore_smelting(event, material, ore, gem) {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/minecraft/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/minecraft/shaped.js
@@ -78,7 +78,7 @@ onEvent('recipes', (event) => {
                 A: 'minecraft:smooth_stone',
                 B: 'minecraft:furnace',
                 C: 'minecraft:campfire',
-                D: ['#forge:plates/iron', '#forge:plates/tin', '#forge:plates/aluminum']
+                D: 'minecraft:terracotta'
             },
             id: 'minecraft:blast_furnace'
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -2,6 +2,7 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+    const id_prefix = 'enigmatica:expert/unification/unify_materials/';
 
     materialsToUnify.forEach((material) => {
         var ingot = getPreferredItemInTag(Ingredient.of(`#forge:ingots/${material}`)).id;
@@ -20,6 +21,7 @@ onEvent('recipes', (event) => {
         var levigated_material = getPreferredItemInTag(Ingredient.of(`#enigmatica:levigated_materials/${material}`)).id;
         var crystalline_sliver = getPreferredItemInTag(Ingredient.of(`#enigmatica:crystalline_slivers/${material}`)).id;
 
+        ore_ingot_smelting(event, material, ore, ingot);
         gear_unification(event, material, ingot, gem, gear);
         rod_unification(event, material, ingot, gem, rod, plate);
         plate_unification(event, material, ingot, gem, plate);
@@ -39,6 +41,28 @@ onEvent('recipes', (event) => {
             crystalline_sliver
         );
     });
+
+    function ore_ingot_smelting(event, material, ore, ingot) {
+        if (ore == air || ingot == air) {
+            return;
+        }
+
+        blacklistedMaterials = ['ender'];
+
+        for (var i = 0; i < blacklistedMaterials.length; i++) {
+            if (blacklistedMaterials[i] == material) {
+                return;
+            }
+        }
+
+        var output = ingot,
+            input = `#forge:ores/${material}`;
+        event.blasting(output, input).xp(0.7).id(`${id_prefix}blasting/${material}/ingot/from_ore`);
+
+        event.recipes.mekanism.smelting(output, input).id(`${id_prefix}smelting/${material}/ingot/from_ore`);
+
+        event.recipes.thermal.furnace(output, input).id(`${id_prefix}furnace/${material}/ingot/from_ore`);
+    }
 
     function gear_unification(event, material, ingot, gem, gear) {
         if (gear == air) {

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
@@ -2,7 +2,7 @@ onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
-    const id_prefix = 'enigmatica:normal/unification/';
+    const id_prefix = 'enigmatica:normal/unification/unify_materials/';
 
     materialsToUnify.forEach((material) => {
         var ingot = getPreferredItemInTag(Ingredient.of('#forge:ingots/' + material)).id;
@@ -16,6 +16,7 @@ onEvent('recipes', (event) => {
         let ore = getPreferredItemInTag(Ingredient.of(`#forge:ores/${material}`)).id;
         let dust = getPreferredItemInTag(Ingredient.of(`#forge:dusts/${material}`)).id;
 
+        minecraft_ore_ingot_smelting(event, material, ore, ingot);
         gear_unification(event, material, ingot, gem, gear);
         rod_unification(event, material, ingot, gem, rod);
         plate_unification(event, material, ingot, gem, plate);
@@ -23,6 +24,25 @@ onEvent('recipes', (event) => {
 
         immersiveengineering_ore_processing_with_secondary_outputs(event, material, ore, dust, ingot);
     });
+
+    function minecraft_ore_ingot_smelting(event, material, ore, ingot) {
+        if (ore == air || ingot == air) {
+            return;
+        }
+
+        blacklistedMaterials = ['ender'];
+
+        for (var i = 0; i < blacklistedMaterials.length; i++) {
+            if (blacklistedMaterials[i] == material) {
+                return;
+            }
+        }
+
+        var output = ingot,
+            input = `#forge:ores/${material}`;
+        event.smelting(output, input).xp(0.7).id(`${id_prefix}smelting/${material}/ingot/from_ore`);
+        event.blasting(output, input).xp(0.7).id(`${id_prefix}blasting/${material}/ingot/from_ore`);
+    }
 
     function gear_unification(event, material, ingot, gem, gear) {
         if (gear == air) {


### PR DESCRIPTION
Since the previous fix wasn't as complete as I thought it was...

This removes ore smelting from the furnace entirely, moving it to the blast furnace and other modded furnaces. It also removes the metal requirements from crafting a blast furnace so as to make it possible to smelt early game still prior to any form of ore processing. 