### PR TITLE
Update file path so that CI can find kubejs.jar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,4 +165,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: compiled (${{ matrix.repo }})
-          path: ./KubeJS/forge/build/libs/kubejs-forge-1605.3.19-build.9999.jar
+          path: ./KubeJS/forge/build/libs/kubejs-forge-1605.3.20-build.9999.jar


### PR DESCRIPTION
## Summary

Days ago I send an issue #5404 reporting that CI will fail at stage "Compile (KubeJS)", that was fixed. 
But when I try CI again at my fork , it will still fail, at stage "mods" , because CI cannot find kubejs.jar. It's the same with what's happening [here](https://github.com/EnigmaticaModpacks/Enigmatica6/actions/runs/5358401630) . 

It turns out that KubeJS also change their `mod_version` in [this commit](https://github.com/KubeJS-Mods/KubeJS/commit/97e880e93c78c95de419f74b56f09beb8a02549a), from `1605.3.19` to `1605.3.20` .

## Testing

Tried on my own fork, [Enigmatica6Enlightened](https://github.com/ZZZank/Enigmatica6Enlightened)
fail before : [before](https://github.com/ZZZank/Enigmatica6Enlightened/actions/runs/5357497442)
success after : [after](https://github.com/ZZZank/Enigmatica6Enlightened/actions/runs/5367943011)