### PR TITLE
Add more valid heat source in quest 'Brazier'

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -118,7 +118,41 @@
 				{
 					id: "5A65288C9B50231B"
 					type: "item"
-					item: "farmersdelight:stove"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							RepairCost: 0
+							items: [
+								{
+									id: "minecraft:campfire"
+									Count: 1b
+								}
+								{
+									id: "minecraft:soul_campfire"
+									Count: 1b
+								}
+								{
+									id: "farmersdelight:stove"
+									Count: 1b
+								}
+								{
+									id: "farmersdelight:skillet"
+									Count: 1b
+									tag: {
+										Damage: 0
+									}
+								}
+								{
+									id: "nethers_delight:blackstone_stove"
+									Count: 1b
+								}
+							]
+							display: {
+								Name: "{\"text\":\"Heat Source\"}"
+							}
+						}
+					}
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -137,7 +137,7 @@
 									Count: 1b
 								}
 								{
-									id: "minecraft:magna"
+									id: "minecraft:magna_block"
 									Count: 1b
 								}
 								{

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -129,27 +129,28 @@
 									Count: 1b
 								}
 								{
-									id: "minecraft:soul_campfire"
-									Count: 1b
-								}
-								{
 									id: "farmersdelight:stove"
 									Count: 1b
 								}
 								{
-									id: "farmersdelight:skillet"
+									id: "minecraft:lava_bucket"
 									Count: 1b
-									tag: {
-										Damage: 0
-									}
+								}
+								{
+									id: "minecraft:magna"
+									Count: 1b
 								}
 								{
 									id: "nethers_delight:blackstone_stove"
 									Count: 1b
 								}
+								{
+									id: "minecraft:soul_campfire"
+									Count: 1b
+								}
 							]
 							display: {
-								Name: "{\"text\":\"Heat Source\"}"
+								Name: "{\"text\":\"Any Heat Source\"}"
 							}
 						}
 					}

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -137,7 +137,7 @@
 									Count: 1b
 								}
 								{
-									id: "minecraft:magna_block"
+									id: "minecraft:magma_block"
 									Count: 1b
 								}
 								{


### PR DESCRIPTION
## Summary
 Same as what the title said. 

 Originally, the quest requires player to get a Stove, as heat source of Cooking Pot. But Cooking Pot accepts many kinds of heat sources, not just Stove. 
 The quest is in chapter 'Magic-Apprentice'
## Testing
<img width="450" alt="image" src="https://github.com/EnigmaticaModpacks/Enigmatica6/assets/47418975/103b2c19-7fbb-49bf-be1f-aa664d2657bd">
<img width="450" alt="image" src="https://github.com/EnigmaticaModpacks/Enigmatica6/assets/47418975/583f16e9-1f14-486f-b454-fe8a7a399d4a">
<img width="574" alt="image" src="https://github.com/EnigmaticaModpacks/Enigmatica6/assets/47418975/bc987c14-6857-4a61-af47-7a199882b601">