### PR TITLE
Allow passing arguments to start-server.sh

### DIFF
--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -31,7 +31,7 @@ else
         echo "Neither wget or curl were found on your system. Please install one and try again"
     fi
 fi
-java -jar serverstarter-2.4.0.jar
+java -jar serverstarter-2.4.0.jar "$@"
 if [[ $DO_RAMDISK -eq 1 ]]; then
     sudo umount "$SAVE_DIR"
     rm -rf "$SAVE_DIR"

--- a/server_files_expert/start-server.sh
+++ b/server_files_expert/start-server.sh
@@ -31,7 +31,7 @@ else
         echo "Neither wget or curl were found on your system. Please install one and try again"
     fi
 fi
-java -jar serverstarter-2.4.0.jar
+java -jar serverstarter-2.4.0.jar "$@"
 if [[ $DO_RAMDISK -eq 1 ]]; then
     sudo umount "$SAVE_DIR"
     rm -rf "$SAVE_DIR"


### PR DESCRIPTION
serverstarter can take an "install" argument to only install the pack but not start it up. I use this for running my Enigmatica modpacks in docker containers; I edit the start-server.sh script as shown in this PR, and then my Dockerfile runs `start-server.sh install` as part of the docker build. And then container startup just runs `start-server.sh` without args like normal. So this PR doesn't affect normal behavior of the script at all.

I can keep editing it every time I download a new version, but I figured I'd contribute this PR in case anyone else finds it helpful, and also then I won't need to edit it myself any more 😅

I don't run in Windows, but I think the equivalent for the `server-start.bat` file would be `%*` -- if anyone wants to test it.