### PR TITLE
cutting recipe for turning Root into Root(item)

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/farmersdelight/cutting.js
@@ -17,6 +17,9 @@ onEvent('recipes', (event) => {
     const id_prefix = 'enigmatica:base/farmersdelight/cutting/';
 
     const recipes = [
+        cuttingRecipe(Ingredient.of('quark:root'), Ingredient.of('#forge:tools/knives'), [
+            Item.of('quark:root_item')
+        ]),
         cuttingRecipe(
             Ingredient.of('#forge:storage_blocks/clay'),
             {


### PR DESCRIPTION
Ported from [here](https://github.com/ZZZank/Enlightened6/commit/de9667dba1cee46a83ac30eb614abc4771e5e1b2)
In expert mode, Redstone Root (from Botania) requires Root item (Quark) to craft, which should not be a problem because Root (block) is craftable. 
But players (like me) sometimes didn't realize this, and will takes redundant efforts in caves just to get a Root (item).

So this PR adds a simple recipe, to tell players that you can turn Root into Root(item)
![image](https://github.com/EnigmaticaModpacks/Enigmatica6/assets/47418975/258070da-e44b-4091-aad9-f8964f3fbf69)
