### PR TITLE
Tagging explosives

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
@@ -1,0 +1,100 @@
+'use strict';
+
+onEvent('item.tags', (event) => {
+    /**
+     * Templates for tagging items, with automatic handling of "base tag".  
+     * E.g. when adding `thermal:ice_tnt` into `#enlightened6:explosives/ice`, it will also be added into `#enlightened6:explosives`  
+     * For a targeted tag, it will first remove entries that match elements in `firstRemove`, then add entries in `thenAdd` into it.  
+     * @type {{tag:string,firstRemove?:any|any[],thenAdd?:any|any[]}[]}
+     * @param tag the tag string WITHOUT `#` prefix, like `forge:ingots` or `why:using/this/tag`
+     * @param firstRemove (Optional) Accepts RegEx, tag string, item string.
+     * @param thenAdd (Optional) Accepts can use RegEx, tag string, item string.
+     */
+    let recipes = [
+        {
+            tag: 'enlightened6:explosives/base',
+            thenAdd: [
+                'minecraft:tnt',
+                'appliedenergistics2:tiny_tnt',
+                'minecraft:tnt_minecart',
+                'thermal:explosive_grenade',
+                'supplementaries:bomb',
+                'archers_paradox:explosive_arrow',
+                'immersiveengineering:he',
+                'apotheosis:explosive_arrow',
+                'botania:lens_explosive'
+            ]
+        },
+        {
+            tag: 'enlightened6:explosives/lightning',
+            thenAdd: [
+                'powah:charged_snowball',
+                'thermal:lightning_charge',
+                'thermal:lightning_grenade',
+                'thermal:lightning_tnt',
+                'thermal:lightning_tnt_minecart',
+                'archers_paradox:lightning_arrow'
+            ]
+        },
+        {
+            tag: 'enlightened6:explosives/ice',
+            thenAdd: [
+                'thermal:ice_charge',
+                'thermal:ice_grenade',
+                'thermal:ice_tnt',
+                'thermal:ice_tnt_minecart'
+            ]
+        },
+        {
+            tag: 'enlightened6:explosives/earth',
+            thenAdd: [
+                'tconstruct:efln_ball',
+                'thermal:earth_charge',
+                'thermal:earth_tnt',
+                'thermal:earth_tnt_minecart',
+                'thermal:earth_grenade'
+            ]
+        },
+        {
+            tag: 'enlightened6:explosives/slime',
+            thenAdd: ['thermal:slime_tnt_minecart', 'thermal:slime_tnt', 'thermal:slime_grenade']
+        },
+        {
+            tag: 'enlightened6:explosives/fire',
+            thenAdd: [
+                'thermal:fire_grenade',
+                'minecraft:fire_charge',
+                'thermal:fire_tnt',
+                'thermal:fire_tnt_minecart',
+                'archers_paradox:blaze_arrow'
+            ]
+        },
+        {
+            tag: 'enlightened6:explosives/ender',
+            thenAdd: ['thermal:ender_grenade', 'thermal:ender_tnt', 'thermal:ender_tnt_minecart']
+        },
+        {
+            tag: 'enlightened6:explosives/glow',
+            thenAdd: ['thermal:glowstone_grenade', 'thermal:glowstone_tnt', 'thermal:glowstone_tnt_minecart']
+        },
+        {
+            tag: 'enlightened6:explosives/redstone',
+            thenAdd: [
+                'thermal:redstone_grenade',
+                'thermal:redstone_tnt',
+                'thermal:redstone_tnt_minecart',
+                'archers_paradox:redstone_arrow'
+            ]
+        }
+    ];
+
+    for (let recipe of recipes) {
+        let firstRemove = recipe.firstRemove ? recipe.firstRemove : [];
+        let thenAdd = recipe.thenAdd ? recipe.thenAdd : [];
+        let tagSplitted = recipe.tag.split('/');
+        for (let i = 0; i < tagSplitted.length; i++) {
+            let tag = tagSplitted.slice(0, i + 1).join('/');
+            event.get(tag).remove(firstRemove).add(thenAdd);
+        }
+    }
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
@@ -15,7 +15,6 @@ onEvent('item.tags', (event) => {
             tag: 'enigmatica:explosives/base',
             thenAdd: [
                 'minecraft:tnt',
-                'appliedenergistics2:tiny_tnt',
                 'minecraft:tnt_minecart',
                 'thermal:explosive_grenade',
                 'supplementaries:bomb',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
@@ -12,7 +12,7 @@ onEvent('item.tags', (event) => {
      */
     let recipes = [
         {
-            tag: 'enlightened6:explosives/base',
+            tag: 'enigmatica:explosives/base',
             thenAdd: [
                 'minecraft:tnt',
                 'appliedenergistics2:tiny_tnt',
@@ -26,7 +26,7 @@ onEvent('item.tags', (event) => {
             ]
         },
         {
-            tag: 'enlightened6:explosives/lightning',
+            tag: 'enigmatica:explosives/lightning',
             thenAdd: [
                 'powah:charged_snowball',
                 'thermal:lightning_charge',
@@ -37,7 +37,7 @@ onEvent('item.tags', (event) => {
             ]
         },
         {
-            tag: 'enlightened6:explosives/ice',
+            tag: 'enigmatica:explosives/ice',
             thenAdd: [
                 'thermal:ice_charge',
                 'thermal:ice_grenade',
@@ -46,7 +46,7 @@ onEvent('item.tags', (event) => {
             ]
         },
         {
-            tag: 'enlightened6:explosives/earth',
+            tag: 'enigmatica:explosives/earth',
             thenAdd: [
                 'tconstruct:efln_ball',
                 'thermal:earth_charge',
@@ -56,11 +56,11 @@ onEvent('item.tags', (event) => {
             ]
         },
         {
-            tag: 'enlightened6:explosives/slime',
+            tag: 'enigmatica:explosives/slime',
             thenAdd: ['thermal:slime_tnt_minecart', 'thermal:slime_tnt', 'thermal:slime_grenade']
         },
         {
-            tag: 'enlightened6:explosives/fire',
+            tag: 'enigmatica:explosives/fire',
             thenAdd: [
                 'thermal:fire_grenade',
                 'minecraft:fire_charge',
@@ -70,15 +70,15 @@ onEvent('item.tags', (event) => {
             ]
         },
         {
-            tag: 'enlightened6:explosives/ender',
+            tag: 'enigmatica:explosives/ender',
             thenAdd: ['thermal:ender_grenade', 'thermal:ender_tnt', 'thermal:ender_tnt_minecart']
         },
         {
-            tag: 'enlightened6:explosives/glow',
+            tag: 'enigmatica:explosives/glow',
             thenAdd: ['thermal:glowstone_grenade', 'thermal:glowstone_tnt', 'thermal:glowstone_tnt_minecart']
         },
         {
-            tag: 'enlightened6:explosives/redstone',
+            tag: 'enigmatica:explosives/redstone',
             thenAdd: [
                 'thermal:redstone_grenade',
                 'thermal:redstone_tnt',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
@@ -90,9 +90,9 @@ onEvent('item.tags', (event) => {
     for (let recipe of recipes) {
         let firstRemove = recipe.firstRemove ? recipe.firstRemove : [];
         let thenAdd = recipe.thenAdd ? recipe.thenAdd : [];
-        let tagSplitted = recipe.tag.split('/');
-        for (let i = 0; i < tagSplitted.length; i++) {
-            let tag = tagSplitted.slice(0, i + 1).join('/');
+        let splitTag = recipe.tag.split('/');
+        for (let i = 0; i < splitTag.length; i++) {
+            let tag = splitTag.slice(0, i + 1).join('/');
             event.get(tag).remove(firstRemove).add(thenAdd);
         }
     }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js
@@ -4,16 +4,16 @@ onEvent('item.tags', (event) => {
     /**
      * Templates for tagging items, with automatic handling of "base tag".  
      * E.g. when adding `thermal:ice_tnt` into `#enlightened6:explosives/ice`, it will also be added into `#enlightened6:explosives`  
-     * For a targeted tag, it will first remove entries that match elements in `firstRemove`, then add entries in `thenAdd` into it.  
-     * @type {{tag:string,firstRemove?:any|any[],thenAdd?:any|any[]}[]}
-     * @param tag the tag string WITHOUT `#` prefix, like `forge:ingots` or `why:using/this/tag`
-     * @param firstRemove (Optional) Accepts RegEx, tag string, item string.
-     * @param thenAdd (Optional) Accepts can use RegEx, tag string, item string.
+     * For a targeted tag, it will first remove entries that match elements in `removals`, then add entries in `additions` into it.  
+     * @type {{tag:string,removals?:any[],additions?:any[]}[]}
+     * @param tag Tag string WITHOUT `#` prefix, like `forge:ingots` or `why:using/this/tag`
+     * @param removals (Optional) Accepts RegEx, tag string, item string.
+     * @param additions (Optional) Accepts RegEx, tag string, item string.
      */
     let recipes = [
         {
             tag: 'enigmatica:explosives/base',
-            thenAdd: [
+            additions: [
                 'minecraft:tnt',
                 'minecraft:tnt_minecart',
                 'thermal:explosive_grenade',
@@ -26,7 +26,7 @@ onEvent('item.tags', (event) => {
         },
         {
             tag: 'enigmatica:explosives/lightning',
-            thenAdd: [
+            additions: [
                 'powah:charged_snowball',
                 'thermal:lightning_charge',
                 'thermal:lightning_grenade',
@@ -37,7 +37,7 @@ onEvent('item.tags', (event) => {
         },
         {
             tag: 'enigmatica:explosives/ice',
-            thenAdd: [
+            additions: [
                 'thermal:ice_charge',
                 'thermal:ice_grenade',
                 'thermal:ice_tnt',
@@ -46,7 +46,7 @@ onEvent('item.tags', (event) => {
         },
         {
             tag: 'enigmatica:explosives/earth',
-            thenAdd: [
+            additions: [
                 'tconstruct:efln_ball',
                 'thermal:earth_charge',
                 'thermal:earth_tnt',
@@ -56,11 +56,11 @@ onEvent('item.tags', (event) => {
         },
         {
             tag: 'enigmatica:explosives/slime',
-            thenAdd: ['thermal:slime_tnt_minecart', 'thermal:slime_tnt', 'thermal:slime_grenade']
+            additions: ['thermal:slime_tnt_minecart', 'thermal:slime_tnt', 'thermal:slime_grenade']
         },
         {
             tag: 'enigmatica:explosives/fire',
-            thenAdd: [
+            additions: [
                 'thermal:fire_grenade',
                 'minecraft:fire_charge',
                 'thermal:fire_tnt',
@@ -70,15 +70,15 @@ onEvent('item.tags', (event) => {
         },
         {
             tag: 'enigmatica:explosives/ender',
-            thenAdd: ['thermal:ender_grenade', 'thermal:ender_tnt', 'thermal:ender_tnt_minecart']
+            additions: ['thermal:ender_grenade', 'thermal:ender_tnt', 'thermal:ender_tnt_minecart']
         },
         {
             tag: 'enigmatica:explosives/glow',
-            thenAdd: ['thermal:glowstone_grenade', 'thermal:glowstone_tnt', 'thermal:glowstone_tnt_minecart']
+            additions: ['thermal:glowstone_grenade', 'thermal:glowstone_tnt', 'thermal:glowstone_tnt_minecart']
         },
         {
             tag: 'enigmatica:explosives/redstone',
-            thenAdd: [
+            additions: [
                 'thermal:redstone_grenade',
                 'thermal:redstone_tnt',
                 'thermal:redstone_tnt_minecart',
@@ -87,13 +87,13 @@ onEvent('item.tags', (event) => {
         }
     ];
 
-    for (let recipe of recipes) {
-        let firstRemove = recipe.firstRemove ? recipe.firstRemove : [];
-        let thenAdd = recipe.thenAdd ? recipe.thenAdd : [];
+    recipes.forEach(recipe => {
+        let removals = recipe.removals ? recipe.removals : [];
+        let additions = recipe.additions ? recipe.additions : [];
         let splitTag = recipe.tag.split('/');
         for (let i = 0; i < splitTag.length; i++) {
             let tag = splitTag.slice(0, i + 1).join('/');
-            event.get(tag).remove(firstRemove).add(thenAdd);
+            event.get(tag).remove(removals).add(additions);
         }
-    }
+    });
 });


### PR DESCRIPTION
Ported from [here](https://github.com/ZZZank/Enlightened6/blob/enlightened_develop/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/explosives.js). 

The main goal of this PR is to provide a infrastructure for effectively handling cases of "nested" tags, like `why:using/this/tag`. E.g. when adding `thermal:ice_tnt` into `#enlightened6:explosives/ice`, it will also be added into `#enlightened6:explosives`. 
Explosives are just used as examples, such infrastructure will be most useful in `#forge:ingots` tagging, but I didn't realize that when making this PR. 

And, I think, if this PR is merged, those filters in quest accepting `charged_snowball or ...` can be replaced with tag filter