### PR TITLE
Fix Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - run: git clone --branch 1605 https://github.com/KubeJS-Mods/KubeJS.git
+      # We're using a forked KubeJS because the origianl one has reached its
+      # end of support, and the most recent, unreleased change is causing crash
+      # in such old codebase
+      - run: git clone --branch 1605 https://github.com/ZZZank/KubeJS.git
       - run: git apply ../.github/actions/ci/patches/kubejs.patch
         working-directory: KubeJS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       # We're using a forked KubeJS because the origianl one has reached its
       # end of support, and the most recent, unreleased change is causing crash
       # in such old codebase
+      # For details, see https://github.com/EnigmaticaModpacks/Enigmatica6/pull/5445
       - run: git clone --branch 1605 https://github.com/ZZZank/KubeJS.git
       - run: git apply ../.github/actions/ci/patches/kubejs.patch
         working-directory: KubeJS


### PR DESCRIPTION
Continuous Integration has been in a semi-broken state for about...4 months? I notice that ever since #5429 , CI will randomly fail even when the script itself is totally safe. 
This PR try to fix such issue. I've tried on my repo: https://github.com/ZZZank/Enlightened6/actions/runs/8151319427 , it seems working pretty well. 
## Reason of CI failing
Most of failed CI will have 5 checks passed, `kubejs(normal)` and `kubejs(expert)` failed. They are failing for the same reason: 
```
> Run node .github/actions/ci/log-kubejs-warnings.js
node:internal/fs/utils:3[5](https://github.com/EnigmaticaModpacks/Enigmatica6/actions/runs/8161086972/job/22309682396#step:7:6)1
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'logs/kubejs/server.txt'
```

This indicates that the `server` job is actually not successful. And I looked into the log, finally finding out that it's failing because of a failed mixin injection from KubeJS: 
```
2024-03-02T06:27:17.0933930Z [06:27:17] [main/FATAL] [mixin/]: Mixin apply failed kubejs-common.mixins.json:UtilMixin -> net.minecraft.util.Util: org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException Critical injection failure: @Inject annotation on shutdownExecutorsKJS could not find any targets matching 'shutdownExecutors' in net.minecraft.util.Util. No refMap loaded. [PREINJECT Applicator Phase -> kubejs-common.mixins.json:UtilMixin -> Prepare Injections ->  -> handler$bhp000$shutdownExecutorsKJS(Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V -> Parse]
2024-03-02T06:27:17.0943735Z org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException: Critical injection failure: @Inject annotation on shutdownExecutorsKJS could not find any targets matching 'shutdownExecutors' in net.minecraft.util.Util. No refMap loaded. [PREINJECT Applicator Phase -> kubejs-common.mixins.json:UtilMixin -> Prepare Injections ->  -> handler$bhp000$shutdownExecutorsKJS(Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V -> Parse]
2024-03-02T06:27:17.0949767Z 	at org.spongepowered.asm.mixin.injection.struct.InjectionInfo.validateTargets(InjectionInfo.java:656) ~[mixin-0.8.4.jar:0.8.4+Jenkins-b308.git-2accda5000f7602229606b39437565542cc6fba4] {re:classloading,re:classloading}
2024-03-02T06:27:17.0953868Z 	at org.spongepowered.asm.mixin.injection.struct.InjectionInfo.findTargets(InjectionInfo.java:587) ~[mixin-0.8.4.jar:0.8.4+Jenkins-b308.git-2accda5000f7602229606b39437565542cc6fba4] {re:classloading,re:classloading}
...
```
More precisely, it's because KubeJS repo on Github includes an unreleased change that add a new mixin([UtilMixin.java](https://github.com/KubeJS-Mods/KubeJS/commit/385df5aea36d74aead177e2a8f2f2d16c8b19cc5#diff-6aa5807225073541bc8e39e62d22b20b16151f5bc1d7a0fb90097ad919c9ebaa)), then magically causing this mixin error mentioned before. 

## Solution
SImple, just fix this mixin error. I made a fork of KubeJS myself, and do some minor changes. [Building test](https://github.com/ZZZank/KubeJS/actions/runs/8151251393) shows that the problem is fixed. 

Fun facts: I didn't actually make any changes to the source code, just update  building toolkits. Then the bug is magically fixed. 

But note that current __KubeJS cache in Actions must be deleted__, otherwise CI will still use the old KubeJS. 