### PR TITLE
remove `const` in for loop

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -50,7 +50,7 @@ function unificationBlacklistEntry(material, type) {
  * @see unificationBlacklist
  */
 function entryIsBlacklisted(material, type) {
-    for (const blackList of unificationBlacklist) {
+    for (let blackList of unificationBlacklist) {
         if (blackList.material == material && blackList.type == type) {
             return true
         }


### PR DESCRIPTION
There was a bug in Lat's Rhino (KubeJS's dependency) that `const` in any kind of for loop will break codes at runtime. It's partially resolved in 1.18+, but not 1.16, so we can't use `const` here :(