### PR TITLE
Fix for Wisteria being unplaceable on Crystalline Dark Oak Logs

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
--   Fix for Wisteria being unplaceable on Crystalline Dark Oak Logs [\#5480](https://github.com/EnigmaticaModpacks/Enigmatica6/issues/5480) ([MuteTiefling](https://github.com/MuteTiefling))
+-   Fix for Wisteria being unplaceable on Crystalline Dark Oak Logs [\#5492](https://github.com/EnigmaticaModpacks/Enigmatica6/issues/5492) ([MuteTiefling](https://github.com/MuteTiefling))
 
 ### Enigmatica 6 & Enigmatica 6: Expert v1.10.0
 

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -1,11 +1,17 @@
+### Enigmatica 6 & Enigmatica 6: Expert v1.11.0
+
+**Bug fixes**
+
+-   Fix for Wisteria being unplaceable on Crystalline Dark Oak Logs [\#5480](https://github.com/EnigmaticaModpacks/Enigmatica6/issues/5480) ([MuteTiefling](https://github.com/MuteTiefling))
+
 ### Enigmatica 6 & Enigmatica 6: Expert v1.10.0
 
 _Using Forge-1.16.5-36.2.39_ | _[Mod Updates](https://github.com/EnigmaticaModpacks/Enigmatica6/blob/master/changelogs/changelog_mods_1.10.0.md)_ | _[Modlist](https://github.com/EnigmaticaModpacks/Enigmatica6/blob/master/changelogs/modlist_1.10.0.md)_
 
 **New Mods**
 
-- [Searchables](https://www.curseforge.com/minecraft/mc-mods/searchables) (by [Jaredlll08](https://www.curseforge.com/members/Jaredlll08/projects))
-- [Structure Layout Optimizer](https://www.curseforge.com/minecraft/mc-mods/structure-layout-optimizer) (by [telepathicgrunt](https://www.curseforge.com/members/telepathicgrunt/projects))
+-   [Searchables](https://www.curseforge.com/minecraft/mc-mods/searchables) (by [Jaredlll08](https://www.curseforge.com/members/Jaredlll08/projects))
+-   [Structure Layout Optimizer](https://www.curseforge.com/minecraft/mc-mods/structure-layout-optimizer) (by [telepathicgrunt](https://www.curseforge.com/members/telepathicgrunt/projects))
 
 **Improvements**
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/minecraft/logs.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/minecraft/logs.js
@@ -1,4 +1,4 @@
 onEvent('block.tags', (event) => {
     event.add('minecraft:birch_logs', ['#byg:palo_verde_logs']);
-    event.add('minecraft:logs', ['#upgrade_aquatic:driftwood_logs']);
+    event.add('minecraft:logs', ['#upgrade_aquatic:driftwood_logs', 'kubejs:crystalline_dark_oak_wood']);
 });


### PR DESCRIPTION
Fix for Wisteria being unplaceable on Crystalline Dark Oak Logs